### PR TITLE
Refactor: replace Font Awesome icons with lucide-react (#5)

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -47,7 +47,7 @@ When submitting a pull request, make sure your title starts with following prefi
 ## Technologies Used
 
 Calcont Whiteboard is primarily built on React.js. To simplify canvas implementation, we use Fabric.js. You can find the documentation for Fabric.js [here](http://fabricjs.com/docs/) .
-Additionally, we use Material-UI for UI components and icons. You can find its link below:
+Additionally, we use Material-UI for UI components and lucide-react for icons. You can find their links below:
 
 - Material-UI: [Documentation](https://mui.com/material-ui/getting-started/)
-- Material-UI Icons: [Link](https://mui.com/material-ui/material-icons/)
+- lucide-react (icons): [Link](https://lucide.dev/icons/)

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -47,7 +47,7 @@ When submitting a pull request, make sure your title starts with following prefi
 ## Technologies Used
 
 Calcont Whiteboard is primarily built on React.js. To simplify canvas implementation, we use Fabric.js. You can find the documentation for Fabric.js [here](http://fabricjs.com/docs/) .
-Additionally, we use Material-UI and Font Awesome for UI components and icons respectively. You can find their links below:
+Additionally, we use Material-UI for UI components and icons. You can find its link below:
 
 - Material-UI: [Documentation](https://mui.com/material-ui/getting-started/)
-- Font Awesome: [Link](https://fontawesome.com/icons)
+- Material-UI Icons: [Link](https://mui.com/material-ui/material-icons/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "bootstrap": "^5.3.0",
         "fabric": "^5.3.0",
         "fabric-history": "^1.7.0",
+        "lucide-react": "^1.28.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
@@ -14775,6 +14776,15 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.28.0.tgz",
+      "integrity": "sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {
@@ -32743,6 +32753,12 @@
       "requires": {
         "yallist": "^3.0.2"
       }
+    },
+    "lucide-react": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.28.0.tgz",
+      "integrity": "sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg==",
+      "requires": {}
     },
     "lz-string": {
       "version": "1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,6 @@
       "dependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
-        "@fortawesome/fontawesome-free": "^6.4.0",
-        "@fortawesome/free-solid-svg-icons": "^6.4.0",
-        "@fortawesome/react-fontawesome": "^0.2.0",
         "@mui/icons-material": "^5.14.6",
         "@mui/material": "^5.14.6",
         "@sentry/cli": "^2.28.6",
@@ -2700,61 +2697,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.1.tgz",
       "integrity": "sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw=="
-    },
-    "node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.0.tgz",
-      "integrity": "sha512-HNii132xfomg5QVZw0HwXXpN22s7VBHQBv9CeOu9tfJnhsWQNd2lmTNi8CSrnw5B+5YOmzu1UoPAyxaXsJ6RgQ==",
-      "hasInstallScript": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-free": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.4.0.tgz",
-      "integrity": "sha512-0NyytTlPJwB/BF5LtRV8rrABDbe3TdTXqNB3PdZ+UUUZAEIrdOJdmABqKjt4AXwIoJNaRVVZEXxpNrqvE1GAYQ==",
-      "hasInstallScript": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.0.tgz",
-      "integrity": "sha512-Bertv8xOiVELz5raB2FlXDPKt+m94MQ3JgDfsVbrqNpLU9+UE2E18GKjLKw+d3XbeYPqg1pzyQKGsrzbw+pPaw==",
-      "hasInstallScript": true,
-      "peer": true,
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.4.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.0.tgz",
-      "integrity": "sha512-kutPeRGWm8V5dltFP1zGjQOEAzaLZj4StdQhWVZnfGFCvAPVvHh8qk5bRrU4KXnRRRNni5tKQI9PBAdI6MP8nQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.4.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/react-fontawesome": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
-      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
-      "dependencies": {
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
-        "react": ">=16.3"
-      }
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.9",
@@ -24186,41 +24128,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.1.tgz",
       "integrity": "sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw=="
-    },
-    "@fortawesome/fontawesome-common-types": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.0.tgz",
-      "integrity": "sha512-HNii132xfomg5QVZw0HwXXpN22s7VBHQBv9CeOu9tfJnhsWQNd2lmTNi8CSrnw5B+5YOmzu1UoPAyxaXsJ6RgQ=="
-    },
-    "@fortawesome/fontawesome-free": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.4.0.tgz",
-      "integrity": "sha512-0NyytTlPJwB/BF5LtRV8rrABDbe3TdTXqNB3PdZ+UUUZAEIrdOJdmABqKjt4AXwIoJNaRVVZEXxpNrqvE1GAYQ=="
-    },
-    "@fortawesome/fontawesome-svg-core": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.0.tgz",
-      "integrity": "sha512-Bertv8xOiVELz5raB2FlXDPKt+m94MQ3JgDfsVbrqNpLU9+UE2E18GKjLKw+d3XbeYPqg1pzyQKGsrzbw+pPaw==",
-      "peer": true,
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "6.4.0"
-      }
-    },
-    "@fortawesome/free-solid-svg-icons": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.0.tgz",
-      "integrity": "sha512-kutPeRGWm8V5dltFP1zGjQOEAzaLZj4StdQhWVZnfGFCvAPVvHh8qk5bRrU4KXnRRRNni5tKQI9PBAdI6MP8nQ==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "6.4.0"
-      }
-    },
-    "@fortawesome/react-fontawesome": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
-      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
-      "requires": {
-        "prop-types": "^15.8.1"
-      }
     },
     "@hono/node-server": {
       "version": "1.19.9",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@fortawesome/fontawesome-free": "^6.4.0",
-    "@fortawesome/free-solid-svg-icons": "^6.4.0",
-    "@fortawesome/react-fontawesome": "^0.2.0",
     "@mui/icons-material": "^5.14.6",
     "@mui/material": "^5.14.6",
     "@sentry/cli": "^2.28.6",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "bootstrap": "^5.3.0",
     "fabric": "^5.3.0",
     "fabric-history": "^1.7.0",
+    "lucide-react": "^1.28.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/src/components/CanvasEditor/Footer/Zoom/ZoomPanel.jsx
+++ b/src/components/CanvasEditor/Footer/Zoom/ZoomPanel.jsx
@@ -1,10 +1,11 @@
 import { useCanvasContext } from "../../../../hooks";
 import "./ZoomPanel.scss";
-import AddIcon from "@mui/icons-material/Add";
-import RemoveIcon from "@mui/icons-material/Remove";
+import { Plus, Minus } from "lucide-react";
 import { handleZoomUtil as handleZoom } from "../../../../utils/Zoom";
 import { Tooltip } from "@mui/material";
 import { useEffect, useState } from "react";
+
+const ICON_SIZE = 18;
 
 const ZoomPanel = () => {
   const { canvas, zoomRatio, setZoomRatio } = useCanvasContext();
@@ -30,9 +31,9 @@ const ZoomPanel = () => {
     <div className="zoom-panel upper">
       <div className="zoom-panel__inner-container">
         <Tooltip title={"Zoom Out"}>
-          <RemoveIcon
+          <Minus
             className="zoom-panel__button"
-            sx={{ fontSize: "var(--default-icon-size)" }}
+            size={ICON_SIZE}
             onClick={handleZoomOut}
           />
         </Tooltip>
@@ -42,9 +43,9 @@ const ZoomPanel = () => {
           </div>
         </Tooltip>
         <Tooltip title={"Zoom In"}>
-          <AddIcon
+          <Plus
             className="zoom-panel__button"
-            sx={{ fontSize: "var(--default-icon-size)" }}
+            size={ICON_SIZE}
             onClick={handleZoomIn}
           />
         </Tooltip>

--- a/src/components/CanvasEditor/Footer/Zoom/ZoomPanel.jsx
+++ b/src/components/CanvasEditor/Footer/Zoom/ZoomPanel.jsx
@@ -1,7 +1,7 @@
 import { useCanvasContext } from "../../../../hooks";
 import "./ZoomPanel.scss";
-import { faPlus, faMinus } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import AddIcon from "@mui/icons-material/Add";
+import RemoveIcon from "@mui/icons-material/Remove";
 import { handleZoomUtil as handleZoom } from "../../../../utils/Zoom";
 import { Tooltip } from "@mui/material";
 import { useEffect, useState } from "react";
@@ -30,9 +30,9 @@ const ZoomPanel = () => {
     <div className="zoom-panel upper">
       <div className="zoom-panel__inner-container">
         <Tooltip title={"Zoom Out"}>
-          <FontAwesomeIcon
-            icon={faMinus}
+          <RemoveIcon
             className="zoom-panel__button"
+            sx={{ fontSize: "var(--default-icon-size)" }}
             onClick={handleZoomOut}
           />
         </Tooltip>
@@ -42,9 +42,9 @@ const ZoomPanel = () => {
           </div>
         </Tooltip>
         <Tooltip title={"Zoom In"}>
-          <FontAwesomeIcon
-            icon={faPlus}
+          <AddIcon
             className="zoom-panel__button"
+            sx={{ fontSize: "var(--default-icon-size)" }}
             onClick={handleZoomIn}
           />
         </Tooltip>

--- a/src/components/CanvasEditor/Header/Menu/Menu.jsx
+++ b/src/components/CanvasEditor/Header/Menu/Menu.jsx
@@ -1,9 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Tooltip } from "@mui/material";
-import LockIcon from "@mui/icons-material/Lock";
-import LockOpenIcon from "@mui/icons-material/LockOpen";
-import DeleteIcon from "@mui/icons-material/Delete";
 import Divider from "@mui/material/Divider";
+import { Lock, Unlock, Trash2 } from "lucide-react";
 import removeCursor from "../../../../assets/icons/circle.svg";
 import GenericDialog from "../../../Dialog/ConsentDialog";
 import BackgroundColor from "../../BackgroundColor";
@@ -11,6 +9,8 @@ import { Image } from "../../../../Handlers/ToolsHandler";
 import { useMenuContext, useCanvasContext } from "../../../../hooks";
 import { iconToolsMaps, TOOL_CONSTANTS } from "../../../../constants";
 import "./menu.scss";
+
+const ICON_SIZE = 18;
 
 const Menu = () => {
   const { activeTool, setActiveTool, lockStatus, setLockStatus } =
@@ -48,7 +48,7 @@ const Menu = () => {
     setActiveTool(TOOL_CONSTANTS.CURSOR);
   };
 
-  const LockToggleIcon = lockStatus ? LockIcon : LockOpenIcon;
+  const LockToggleIcon = lockStatus ? Lock : Unlock;
 
   return (
     <>
@@ -57,7 +57,7 @@ const Menu = () => {
           <Tooltip title={"Keep selected tool active after drawing"}>
             <LockToggleIcon
               className="menu-container__button"
-              sx={{ fontSize: "var(--default-icon-size)" }}
+              size={ICON_SIZE}
               onClick={handleLock}
             />
           </Tooltip>
@@ -72,7 +72,7 @@ const Menu = () => {
                       ? "menu-container__button active"
                       : "menu-container__button"
                   }
-                  sx={{ fontSize: "var(--default-icon-size)" }}
+                  size={ICON_SIZE}
                   onClick={(event) => onToolClick(tool.id, event)}
                 />
               </Tooltip>
@@ -80,9 +80,9 @@ const Menu = () => {
           })}
           <Divider orientation="vertical" flexItem />
           <Tooltip title={"Delete entire canvas"}>
-            <DeleteIcon
+            <Trash2
               className="menu-container__button"
-              sx={{ fontSize: "var(--default-icon-size)" }}
+              size={ICON_SIZE}
               onClick={() => setIsDeleteDialogOpen(true)}
             />
           </Tooltip>

--- a/src/components/CanvasEditor/Header/Menu/Menu.jsx
+++ b/src/components/CanvasEditor/Header/Menu/Menu.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from "react";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Tooltip } from "@mui/material";
-import { faLock, faLockOpen, faTrash } from "@fortawesome/free-solid-svg-icons";
+import LockIcon from "@mui/icons-material/Lock";
+import LockOpenIcon from "@mui/icons-material/LockOpen";
+import DeleteIcon from "@mui/icons-material/Delete";
 import Divider from "@mui/material/Divider";
 import removeCursor from "../../../../assets/icons/circle.svg";
 import GenericDialog from "../../../Dialog/ConsentDialog";
@@ -47,36 +48,41 @@ const Menu = () => {
     setActiveTool(TOOL_CONSTANTS.CURSOR);
   };
 
+  const LockToggleIcon = lockStatus ? LockIcon : LockOpenIcon;
+
   return (
     <>
       <div className="menu-container upper">
         <div className="menu-container__inner-container ">
           <Tooltip title={"Keep selected tool active after drawing"}>
-            <FontAwesomeIcon
-              icon={lockStatus ? faLock : faLockOpen}
+            <LockToggleIcon
               className="menu-container__button"
+              sx={{ fontSize: "var(--default-icon-size)" }}
               onClick={handleLock}
             />
           </Tooltip>
           <Divider orientation="vertical" flexItem />
-          {iconToolsMaps.map((tool, index) => (
-            <Tooltip title={tool.title} key={index}>
-              <FontAwesomeIcon
-                icon={tool.icon}
-                className={
-                  activeTool === `${tool.id}`
-                    ? "menu-container__button active"
-                    : "menu-container__button"
-                }
-                onClick={(event) => onToolClick(tool.id, event)}
-              />
-            </Tooltip>
-          ))}
+          {iconToolsMaps.map((tool, index) => {
+            const ToolIcon = tool.icon;
+            return (
+              <Tooltip title={tool.title} key={index}>
+                <ToolIcon
+                  className={
+                    activeTool === `${tool.id}`
+                      ? "menu-container__button active"
+                      : "menu-container__button"
+                  }
+                  sx={{ fontSize: "var(--default-icon-size)" }}
+                  onClick={(event) => onToolClick(tool.id, event)}
+                />
+              </Tooltip>
+            );
+          })}
           <Divider orientation="vertical" flexItem />
           <Tooltip title={"Delete entire canvas"}>
-            <FontAwesomeIcon
-              icon={faTrash}
+            <DeleteIcon
               className="menu-container__button"
+              sx={{ fontSize: "var(--default-icon-size)" }}
               onClick={() => setIsDeleteDialogOpen(true)}
             />
           </Tooltip>

--- a/src/components/CanvasEditor/Header/Menu/menu.scss
+++ b/src/components/CanvasEditor/Header/Menu/menu.scss
@@ -19,7 +19,6 @@
   }
 
   &__button {
-    width: var(--default-icon-size);
     margin: 0 5px;
     padding: 8px 10px;
     border: none;

--- a/src/constants/IconTools.js
+++ b/src/constants/IconTools.js
@@ -1,32 +1,30 @@
-import {
-  faMarker,
-  faSquare,
-  faCircle,
-  faArrowRight,
-  faMinus,
-  faPalette,
-  faFont,
-  faImage,
-  faArrowPointer,
-  faDiamond,
-  faEraser,
-} from "@fortawesome/free-solid-svg-icons";
+import NearMeIcon from "@mui/icons-material/NearMe";
+import BrushIcon from "@mui/icons-material/Brush";
+import CropSquareIcon from "@mui/icons-material/CropSquare";
+import CircleIcon from "@mui/icons-material/Circle";
+import DiamondIcon from "@mui/icons-material/Diamond";
+import HorizontalRuleIcon from "@mui/icons-material/HorizontalRule";
+import ArrowRightAltIcon from "@mui/icons-material/ArrowRightAlt";
+import TextFieldsIcon from "@mui/icons-material/TextFields";
+import ImageIcon from "@mui/icons-material/Image";
+import PaletteIcon from "@mui/icons-material/Palette";
+import AutoFixNormalIcon from "@mui/icons-material/AutoFixNormal";
 import { TOOL_CONSTANTS } from "./tools";
 
 export const iconToolsMaps = [
-  { icon: faArrowPointer, title: "Select", id: TOOL_CONSTANTS.CURSOR },
-  { icon: faMarker, title: "Marker", id: TOOL_CONSTANTS.MARKER },
-  { icon: faSquare, title: "Rectangle", id: TOOL_CONSTANTS.RECTANGLE },
-  { icon: faCircle, title: "Circle", id: TOOL_CONSTANTS.CIRCLE },
-  { icon: faDiamond, title: "Diamond", id: TOOL_CONSTANTS.DIAMOND },
-  { icon: faMinus, title: "Line", id: TOOL_CONSTANTS.LINE },
-  { icon: faArrowRight, title: "Arrow", id: TOOL_CONSTANTS.ARROW },
-  { icon: faFont, title: "Text", id: TOOL_CONSTANTS.FONT },
-  { icon: faImage, title: "Image", id: TOOL_CONSTANTS.IMAGE },
+  { icon: NearMeIcon, title: "Select", id: TOOL_CONSTANTS.CURSOR },
+  { icon: BrushIcon, title: "Marker", id: TOOL_CONSTANTS.MARKER },
+  { icon: CropSquareIcon, title: "Rectangle", id: TOOL_CONSTANTS.RECTANGLE },
+  { icon: CircleIcon, title: "Circle", id: TOOL_CONSTANTS.CIRCLE },
+  { icon: DiamondIcon, title: "Diamond", id: TOOL_CONSTANTS.DIAMOND },
+  { icon: HorizontalRuleIcon, title: "Line", id: TOOL_CONSTANTS.LINE },
+  { icon: ArrowRightAltIcon, title: "Arrow", id: TOOL_CONSTANTS.ARROW },
+  { icon: TextFieldsIcon, title: "Text", id: TOOL_CONSTANTS.FONT },
+  { icon: ImageIcon, title: "Image", id: TOOL_CONSTANTS.IMAGE },
   {
-    icon: faPalette,
+    icon: PaletteIcon,
     title: "Background Color",
     id: TOOL_CONSTANTS.BACKGROUND_COLOR,
   },
-  { icon: faEraser, title: "Eraser", id: TOOL_CONSTANTS.ERASER },
+  { icon: AutoFixNormalIcon, title: "Eraser", id: TOOL_CONSTANTS.ERASER },
 ];

--- a/src/constants/IconTools.js
+++ b/src/constants/IconTools.js
@@ -1,30 +1,32 @@
-import NearMeIcon from "@mui/icons-material/NearMe";
-import BrushIcon from "@mui/icons-material/Brush";
-import CropSquareIcon from "@mui/icons-material/CropSquare";
-import CircleIcon from "@mui/icons-material/Circle";
-import DiamondIcon from "@mui/icons-material/Diamond";
-import HorizontalRuleIcon from "@mui/icons-material/HorizontalRule";
-import ArrowRightAltIcon from "@mui/icons-material/ArrowRightAlt";
-import TextFieldsIcon from "@mui/icons-material/TextFields";
-import ImageIcon from "@mui/icons-material/Image";
-import PaletteIcon from "@mui/icons-material/Palette";
-import AutoFixNormalIcon from "@mui/icons-material/AutoFixNormal";
+import {
+  MousePointer2,
+  Brush,
+  Square,
+  Circle,
+  Diamond,
+  Minus,
+  ArrowRight,
+  Type,
+  Image as ImageIcon,
+  Palette,
+  Eraser,
+} from "lucide-react";
 import { TOOL_CONSTANTS } from "./tools";
 
 export const iconToolsMaps = [
-  { icon: NearMeIcon, title: "Select", id: TOOL_CONSTANTS.CURSOR },
-  { icon: BrushIcon, title: "Marker", id: TOOL_CONSTANTS.MARKER },
-  { icon: CropSquareIcon, title: "Rectangle", id: TOOL_CONSTANTS.RECTANGLE },
-  { icon: CircleIcon, title: "Circle", id: TOOL_CONSTANTS.CIRCLE },
-  { icon: DiamondIcon, title: "Diamond", id: TOOL_CONSTANTS.DIAMOND },
-  { icon: HorizontalRuleIcon, title: "Line", id: TOOL_CONSTANTS.LINE },
-  { icon: ArrowRightAltIcon, title: "Arrow", id: TOOL_CONSTANTS.ARROW },
-  { icon: TextFieldsIcon, title: "Text", id: TOOL_CONSTANTS.FONT },
+  { icon: MousePointer2, title: "Select", id: TOOL_CONSTANTS.CURSOR },
+  { icon: Brush, title: "Marker", id: TOOL_CONSTANTS.MARKER },
+  { icon: Square, title: "Rectangle", id: TOOL_CONSTANTS.RECTANGLE },
+  { icon: Circle, title: "Circle", id: TOOL_CONSTANTS.CIRCLE },
+  { icon: Diamond, title: "Diamond", id: TOOL_CONSTANTS.DIAMOND },
+  { icon: Minus, title: "Line", id: TOOL_CONSTANTS.LINE },
+  { icon: ArrowRight, title: "Arrow", id: TOOL_CONSTANTS.ARROW },
+  { icon: Type, title: "Text", id: TOOL_CONSTANTS.FONT },
   { icon: ImageIcon, title: "Image", id: TOOL_CONSTANTS.IMAGE },
   {
-    icon: PaletteIcon,
+    icon: Palette,
     title: "Background Color",
     id: TOOL_CONSTANTS.BACKGROUND_COLOR,
   },
-  { icon: AutoFixNormalIcon, title: "Eraser", id: TOOL_CONSTANTS.ERASER },
+  { icon: Eraser, title: "Eraser", id: TOOL_CONSTANTS.ERASER },
 ];


### PR DESCRIPTION
## What changed
Removes Font Awesome and moves the toolbar/zoom/lock/trash icons to **lucide-react** line icons (uniform 18px).

- All FA icons swapped to lucide equivalents in `IconTools.js`, `Menu.jsx`, `ZoomPanel.jsx`.
- Removed the three `@fortawesome/*` packages from `package.json` + lockfile; added `lucide-react`.
- Dropped the fixed icon `width` in `menu.scss` so the SVG `size` prop governs (keeps icons square).
- Updated `CONTRIBUTION.md`.

### Why lucide (not Material UI)
The issue suggested Material UI, but the MUI glyphs looked heavy/inconsistent for the toolbar. lucide's line style suits the whiteboard UI and, unlike Material icons, provides an actual **Eraser** and a proper **Diamond** rhombus. (The commit history shows the MUI pass first, then the switch to lucide.)

### Out of scope
The remaining `@mui/icons-material` usages — GitHub/Twitter socials, the help "?", the export chevron, and the left menu — predate this PR and are left untouched.

## Verification
- `npm run build` compiles clean; `npm run test:format` (prettier) passes.
- Ran the dev server and confirmed the full toolbar + zoom icons render at 18px with the active-tool highlight intact.

> Note: the `test:code` (ESLint) CI step is already red on `master` for every PR (ESLint 9 + legacy `.eslintrc.js`); unrelated to this change.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)