### PR TITLE
Style: move Beta tag next to the shortcut title in Help dialog (#10)

### DIFF
--- a/src/components/CanvasEditor/Footer/Help/Help.jsx
+++ b/src/components/CanvasEditor/Footer/Help/Help.jsx
@@ -93,19 +93,22 @@ function HelpDialog({ open, onClose }) {
                     key={index}
                     className="help-dialog__shortcuts-shortcut"
                   >
-                    <ListItemText
-                      primaryTypographyProps={{ fontSize: "14px" }}
-                      primary={shortcut.name}
-                    />
-                    {shortcut.release && (
-                      <Chip
-                        label={shortcut.release}
-                        className="help-dialog__shortcuts-chip"
-                        variant="outlined"
-                        size="small"
-                        color="primary"
+                    <div className="help-dialog__shortcuts-shortcut-label">
+                      <ListItemText
+                        primaryTypographyProps={{ fontSize: "14px" }}
+                        primary={shortcut.name}
+                        sx={{ flex: "0 0 auto", m: 0 }}
                       />
-                    )}
+                      {shortcut.release && (
+                        <Chip
+                          label={shortcut.release}
+                          className="help-dialog__shortcuts-chip"
+                          variant="outlined"
+                          size="small"
+                          color="primary"
+                        />
+                      )}
+                    </div>
                     <ListItemIcon>
                       {shortcut.key.split("&").map((key, index) => (
                         <kbd

--- a/src/components/CanvasEditor/Footer/Help/Help.scss
+++ b/src/components/CanvasEditor/Footer/Help/Help.scss
@@ -44,6 +44,15 @@
       }
     }
 
+    // Keep the shortcut title and its release chip together on the left; the
+    // flex-grow pushes the key(s) to the far right of the row.
+    &-shortcut-label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex: 1 1 auto;
+    }
+
     &-shortcut-key {
       background-color: var(--default-theme-color);
       margin: 0 5px;


### PR DESCRIPTION
## What changed
In the Help dialog's keyboard-shortcut rows, the `Beta` release chip was rendered as a sibling of `ListItemText`. Since `ListItemText` grows to fill the row, it pushed the chip to the far right — so `Beta` sat immediately to the *left of the keys* instead of next to its title (per the screenshot in #10).

Fix: wrap the title + chip in a flex label group (`flex: 1 1 auto`), so the title and `Beta` stay together on the left and the key(s) are pushed to the right edge.

Only `Help.jsx` and `Help.scss` change.

## Verification
Opened the Help dialog in the running app — `Undo [Beta] ........ Ctrl Z` and `Redo [Beta] ...... Ctrl Shift Z`, with `Beta` snug against its title and keys right-aligned.

> Supersedes the stale 2024 community PR #13 (which was mostly reformatting and no longer merges cleanly). CI's `test:code` (ESLint) step is pre-existing red on `master`.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)