### PR TITLE
Feature: OS-aware keyboard shortcuts (Cmd on macOS)

### DIFF
--- a/src/constants/KeyboarShorcuts.js
+++ b/src/constants/KeyboarShorcuts.js
@@ -1,12 +1,18 @@
-// used & as a separator between keys
+import { isMacOS } from "../utils/platform";
+
+// Show platform-appropriate modifier labels: Cmd (⌘) / ⇧ on macOS, Ctrl / Shift
+// elsewhere. "&" is used as a separator between keys.
+const MOD = isMacOS() ? "⌘" : "Ctrl";
+const SHIFT = isMacOS() ? "⇧" : "Shift";
+
 export const SHORTCUTS = [
-  { name: "Select all the objects", key: "Ctrl & A" },
-  { name: "Duplicate the objects", key: "Ctrl & D" },
+  { name: "Select all the objects", key: `${MOD} & A` },
+  { name: "Duplicate the objects", key: `${MOD} & D` },
   { name: "Delete the objects", key: "Delete" },
   { name: "Move the objects", key: "Arrow keys" },
-  { name: "Zoom in", key: "Ctrl & +" },
-  { name: "Zoom out", key: "Ctrl & -" },
-  { name: "Multi-objects selection", key: "shift & click" },
-  { name: "Undo", key: "Ctrl & Z", release: "Beta" },
-  { name: "Redo", key: "Ctrl & Shift & Z", release: "Beta" },
+  { name: "Zoom in", key: `${MOD} & +` },
+  { name: "Zoom out", key: `${MOD} & -` },
+  { name: "Multi-objects selection", key: `${SHIFT} & click` },
+  { name: "Undo", key: `${MOD} & Z`, release: "Beta" },
+  { name: "Redo", key: `${MOD} & ${SHIFT} & Z`, release: "Beta" },
 ];

--- a/src/utils/Shortcuts.js
+++ b/src/utils/Shortcuts.js
@@ -1,24 +1,27 @@
+// Accept Cmd (metaKey) as well as Ctrl so the shortcuts work on macOS too.
+const isMod = (e) => e.ctrlKey || e.metaKey;
+
 export const isCtrlZ = (e) => {
-  return e.ctrlKey && !e.shiftKey && e.code === "KeyZ";
+  return isMod(e) && !e.shiftKey && e.code === "KeyZ";
 };
 export const isCtrlShiftZ = (e) => {
-  return e.ctrlKey && e.shiftKey && e.code === "KeyZ";
+  return isMod(e) && e.shiftKey && e.code === "KeyZ";
 };
 
 export const isCtrlD = (e) => {
-  return e.ctrlKey && !e.shiftKey && e.code === "KeyD";
+  return isMod(e) && !e.shiftKey && e.code === "KeyD";
 };
 
 export const isCtrlA = (e) => {
-  return e.ctrlKey && !e.shiftKey && e.code === "KeyA";
+  return isMod(e) && !e.shiftKey && e.code === "KeyA";
 };
 
 export const isCtrlPlus = (e) => {
-  return e.ctrlKey && !e.shiftKey && e.code === "Equal";
+  return isMod(e) && !e.shiftKey && e.code === "Equal";
 };
 
 export const isCtrlMinus = (e) => {
-  return e.ctrlKey && !e.shiftKey && e.code === "Minus";
+  return isMod(e) && !e.shiftKey && e.code === "Minus";
 };
 
 export const isArrow = (e) => {

--- a/src/utils/platform.js
+++ b/src/utils/platform.js
@@ -1,0 +1,11 @@
+// Detect macOS so keyboard shortcuts can use the Cmd (⌘) modifier and label
+// instead of Ctrl, matching platform conventions.
+export const isMacOS = () => {
+  if (typeof navigator === "undefined") return false;
+  const platform =
+    navigator.userAgentData?.platform ||
+    navigator.platform ||
+    navigator.userAgent ||
+    "";
+  return /mac/i.test(platform);
+};


### PR DESCRIPTION
## What changed
The Help dialog always displayed `Ctrl`, and the handlers only matched `e.ctrlKey` — so on macOS the natural **Cmd** shortcuts did nothing and the shortcuts screen was misleading.

- New `isMacOS()` platform helper (`src/utils/platform.js`).
- **Handlers** (`utils/Shortcuts.js`) now accept `Cmd` (`metaKey`) as well as `Ctrl`, so `Cmd+Z / Cmd+A / Cmd+D / Cmd±` work on macOS while `Ctrl` keeps working on Windows/Linux.
- **Help dialog** (`constants/KeyboarShorcuts.js`) renders platform-appropriate labels: `⌘` / `⇧` on macOS, `Ctrl` / `Shift` elsewhere.

## Verification
On macOS, the Help dialog now shows `⌘ A`, `⌘ D`, `⌘ +`, `⌘ -`, `⇧ click`, `⌘ Z`, `⌘ ⇧ Z` (screenshot-verified in the running app).

> Note: `test:code` (ESLint) is pre-existing red on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)