### PR TITLE
Feature: pan the canvas by scrolling (wheel / trackpad)

### DIFF
--- a/src/Handlers/EventHandlers/mouseHandler.js
+++ b/src/Handlers/EventHandlers/mouseHandler.js
@@ -1,3 +1,4 @@
+import { fabric } from "fabric";
 import { TOOL_CONSTANTS, TOOL_FUNCTIONS } from "../../constants";
 import { useCanvasContext, useMenuContext } from "../../hooks";
 import { useCallback, useEffect, useRef } from "react";
@@ -72,18 +73,24 @@ function MouseHandler() {
 
   const onMouseWheel = useCallback(
     (event) => {
-      if (canvas && event.e.ctrlKey) {
+      if (!canvas) return;
+      if (event.e.ctrlKey) {
+        // Ctrl + wheel (and trackpad pinch) zooms.
         const delta = event.e.deltaY;
         let zoom = canvas.getZoom();
         zoom *= 0.999 ** delta;
         if (zoom > 20) zoom = 20;
         if (zoom < 0.01) zoom = 0.01;
         setZoomRatio(zoom);
+      } else {
+        // Plain wheel / two-finger trackpad scroll pans the viewport, so you
+        // can reach content drawn outside the current view without zooming out.
+        canvas.relativePan(new fabric.Point(-event.e.deltaX, -event.e.deltaY));
       }
       event.e.preventDefault();
       event.e.stopPropagation();
     },
-    [canvas],
+    [canvas, setZoomRatio],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Problem
There was no way to reach content drawn outside the current view except zooming out — the canvas didn't scroll/pan.

## Fix
Extend the `mouse:wheel` handler:
- **Ctrl + wheel** (and trackpad pinch) → zoom (unchanged).
- **Plain wheel / two-finger trackpad scroll** → pan the viewport via `canvas.relativePan(-deltaX, -deltaY)`, in any direction.

## Verified
A plain wheel event translates `viewportTransform` by exactly `(-deltaX, -deltaY)`; Ctrl+wheel still zooms.

## Possible follow-ups
- Space-bar + drag (and/or middle-mouse drag) to pan, for mouse users who prefer dragging.
- A "reset view" / fit-to-content control.

> Note: `test:code` (ESLint) is pre-existing red on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)