### PR TITLE
Bug Fix: Delete key removes an arrow (fabric Group) instead of no-op

### DIFF
--- a/src/Handlers/EventHandlers/keyBoardHandler.js
+++ b/src/Handlers/EventHandlers/keyBoardHandler.js
@@ -36,11 +36,16 @@ function KeyBoardHandler() {
 
   const handleDeleteSelected = () => {
     if (!activeObject || !canvas) return;
-    // Snapshot the targets first: an active selection exposes its members on
-    // _objects; a single object is deleted on its own.
-    const targets = activeObject._objects
-      ? [...activeObject._objects]
-      : [activeObject];
+    // An active selection exposes the selected canvas objects on _objects and
+    // each must be removed individually. A single object — including a Group
+    // such as an arrow (which also has _objects, but whose children live
+    // inside the group, not on the canvas) — is removed on its own. Only treat
+    // _objects as removal targets for an activeSelection, or a Group never gets
+    // deleted.
+    const targets =
+      activeObject.type === "activeSelection"
+        ? [...activeObject._objects]
+        : [activeObject];
     runAsSingleHistoryStep(canvas, () => {
       canvas.discardActiveObject();
       targets.forEach((obj) => canvas.remove(obj));


### PR DESCRIPTION
## Problem
Selecting an **arrow** and pressing **Delete** did nothing — the arrow couldn't be removed.

## Root cause
`handleDeleteSelected` used `activeObject._objects ? [...activeObject._objects] : [activeObject]`. That's correct for an **activeSelection** (its `_objects` are the selected canvas objects). But a fabric **Group** — which the arrow is (line + head) — *also* exposes `_objects`, and those children live *inside* the group, not on the canvas. So `canvas.remove(child)` was a no-op and the group was never deleted.

## Fix
Only treat `_objects` as removal targets for an `activeSelection`; delete a single object — **including a Group** — on its own.

## Verified (running app, real Delete-key path)
Draw an arrow → select it → press Delete → arrow removed (objects 1 → 0). Single shapes and multi-select delete still work.

## Note on the other reported items
- **Text invisible**: this was the properties-panel overlapping the canvas; fixed in #81 by moving the panel to the top-left. (A recording made before that deploy would still show it.)
- **"Can't create a new arrow after several attempts"**: I couldn't reproduce this with clean or interleaved draws — it appears to be a side effect of undeletable arrows piling up (this fix) and/or very short drags that fall under the arrow's delete-threshold. Please re-test once this + #81 are deployed.

> Note: `test:code` (ESLint) is pre-existing red on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)