### PR TITLE
Fix: Backspace deletes the selection (Mac delete key), not just Forward-Delete

### DIFF
--- a/src/Handlers/EventHandlers/keyBoardHandler.js
+++ b/src/Handlers/EventHandlers/keyBoardHandler.js
@@ -136,8 +136,14 @@ function KeyBoardHandler() {
   useEffect(() => {
     const keyManager = (e) => {
       switch (true) {
-        case e.keyCode === 46: // delete selected objects
-          handleDeleteSelected(canvas);
+        // Delete (46, = fn+Delete on Mac) and Backspace (8, the Mac "delete"
+        // key) both remove the selection — but not while a text is being
+        // edited, where Backspace must delete a character instead.
+        case e.keyCode === 46 || e.keyCode === 8:
+          if (activeObject && !activeObject.isEditing) {
+            e.preventDefault();
+            handleDeleteSelected(canvas);
+          }
           break;
         case isCtrlD(e): // duplicate selected objects
           e.preventDefault();


### PR DESCRIPTION
## Problem
On macOS you had to press **fn+Delete** to remove a selected object; the normal **Delete** (Backspace) key did nothing.

## Cause
The keydown handler only matched **keyCode 46 (Forward Delete)** — which is what `fn+Delete` sends on a Mac. The regular Mac delete key is **Backspace (keyCode 8)**, which was ignored.

## Fix
Handle **both 8 and 46**, guarded so Backspace still deletes a *character* while a text object is being edited (`isEditing`), not the whole object. `preventDefault()` only when we actually delete.

## Verified
- Backspace on a selected shape → removed.
- Backspace while editing a text → deletes a character, object stays.

> Note: `test:code` (ESLint) is pre-existing red on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)