### PR TITLE
Feature: persist the board to IndexedDB (survives page reload)

### DIFF
--- a/src/Handlers/EventHandlers/index.js
+++ b/src/Handlers/EventHandlers/index.js
@@ -3,3 +3,4 @@ export { default as MouseHandler } from "./mouseHandler";
 export { default as SelectionHandler } from "./selectionHandler";
 export { default as TextEventHandler } from "./textEventHandler";
 export { default as ZoomHandler } from "./zoomHandler";
+export { default as PersistenceHandler } from "./persistenceHandler";

--- a/src/Handlers/EventHandlers/persistenceHandler.js
+++ b/src/Handlers/EventHandlers/persistenceHandler.js
@@ -1,0 +1,57 @@
+import { useEffect, useRef } from "react";
+import { useCanvasContext } from "../../hooks";
+import { loadScene, saveScene } from "../../utils/storage";
+
+const SAVE_DEBOUNCE_MS = 800;
+
+// Restores the board from IndexedDB on load and auto-saves (debounced) on
+// every change, so a refresh doesn't lose work.
+function PersistenceHandler() {
+  const { canvas } = useCanvasContext();
+  const saveTimer = useRef(null);
+
+  useEffect(() => {
+    if (!canvas) return undefined;
+    let disposed = false;
+
+    loadScene().then((scene) => {
+      if (disposed || !scene) return;
+      canvas.loadFromJSON(scene, () => {
+        // Restored objects should be selectable once the cursor tool is used.
+        canvas.getObjects().forEach((obj) => obj.set({ selectable: true }));
+        canvas.renderAll();
+        // Reset the history baseline so the restored scene is the starting
+        // point — otherwise an undo would wipe it back to empty.
+        if (Array.isArray(canvas.historyUndo)) {
+          canvas.historyUndo = [];
+          canvas.historyRedo = [];
+          canvas.historyNextState = canvas._historyNext();
+        }
+      });
+    });
+
+    const scheduleSave = () => {
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+      saveTimer.current = setTimeout(() => {
+        saveScene(canvas.toJSON());
+      }, SAVE_DEBOUNCE_MS);
+    };
+
+    const events = [
+      "object:added",
+      "object:modified",
+      "object:removed",
+      "path:created",
+      "background:changed", // fired by the background-color tool
+    ];
+    events.forEach((ev) => canvas.on(ev, scheduleSave));
+
+    return () => {
+      disposed = true;
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+      events.forEach((ev) => canvas.off(ev, scheduleSave));
+    };
+  }, [canvas]);
+}
+
+export default PersistenceHandler;

--- a/src/components/Canvas/Canvas.jsx
+++ b/src/components/Canvas/Canvas.jsx
@@ -8,6 +8,7 @@ import {
   SelectionHandler,
   TextEventHandler,
   ZoomHandler,
+  PersistenceHandler,
 } from "../../Handlers/EventHandlers";
 
 function Canvas() {
@@ -16,6 +17,7 @@ function Canvas() {
   SelectionHandler();
   TextEventHandler();
   ZoomHandler();
+  PersistenceHandler();
   const canvasRef = useRef(null);
   const { setCanvas } = useCanvasContext();
 

--- a/src/components/CanvasEditor/BackgroundColor.jsx
+++ b/src/components/CanvasEditor/BackgroundColor.jsx
@@ -45,6 +45,8 @@ const BackgroundColor = ({ open, anchorEl, onClose }) => {
     document.getElementsByTagName("body")[0].style.backgroundColor = color;
     canvas.backgroundColor = color;
     canvas.renderAll();
+    // Not a native fabric event — let the persistence handler save the change.
+    canvas.fire("background:changed");
   };
 
   return (

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,0 +1,61 @@
+// Minimal, dependency-free IndexedDB store for the whiteboard scene.
+// IndexedDB (not localStorage) because a serialized canvas embeds images as
+// base64 data URLs and easily exceeds localStorage's ~5MB quota.
+
+const DB_NAME = "whiteboard";
+const STORE = "state";
+const SCENE_KEY = "scene";
+
+const openDB = () =>
+  new Promise((resolve, reject) => {
+    if (typeof indexedDB === "undefined") {
+      reject(new Error("IndexedDB unavailable"));
+      return;
+    }
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      if (!req.result.objectStoreNames.contains(STORE)) {
+        req.result.createObjectStore(STORE);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+
+// Load the saved scene object, or null if none / on any failure.
+export const loadScene = async () => {
+  try {
+    const db = await openDB();
+    return await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE, "readonly");
+      const req = tx.objectStore(STORE).get(SCENE_KEY);
+      req.onsuccess = () => resolve(req.result ?? null);
+      req.onerror = () => reject(req.error);
+      tx.oncomplete = () => db.close();
+    });
+  } catch {
+    return null;
+  }
+};
+
+// Persist the scene object (a fabric canvas.toJSON()). Failures are swallowed —
+// persistence is best-effort and must never break drawing.
+export const saveScene = async (scene) => {
+  try {
+    const db = await openDB();
+    await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE, "readwrite");
+      tx.objectStore(STORE).put(scene, SCENE_KEY);
+      tx.oncomplete = () => {
+        db.close();
+        resolve();
+      };
+      tx.onerror = () => {
+        db.close();
+        reject(tx.error);
+      };
+    });
+  } catch {
+    /* best-effort */
+  }
+};


### PR DESCRIPTION
## What
The whiteboard was wiped on every refresh. This auto-saves the scene and restores it on load.

## Why IndexedDB (not localStorage)
As you flagged — a serialized fabric canvas embeds images as **base64 data URLs**, which blow past localStorage's ~5MB quota fast. IndexedDB's quota is hundreds of MB+, so the whole `toJSON()` (images included) fits in one record. (Excalidraw uses a hybrid — scene in localStorage, image blobs in IndexedDB — but for a single local board, all-IndexedDB is simpler and robust.)

## How
- **`src/utils/storage.js`** — minimal, dependency-free IndexedDB `load`/`save` (one `scene` record).
- **`PersistenceHandler`** (new event handler):
  - **Restore** on mount via `canvas.loadFromJSON`, then **reset the fabric-history baseline** (`historyUndo/Redo = []`, refresh `historyNextState`) so an undo can't roll the restored scene back to empty.
  - **Save** `canvas.toJSON()` debounced (800ms) on `object:added/modified/removed`, `path:created`, and a new `background:changed` event the background-color tool now fires (background color isn't a native fabric event).
- Best-effort throughout — a storage failure never breaks drawing.

## Verified end to end
Drew rect + circle + arrow → waited for the debounced save → confirmed the record in IndexedDB (3 objects) → **reloaded the page** → all 3 restored, `historyUndo` clean. Clearing the canvas persists too (fires `object:removed`).

## Possible follow-ups
- A "clear board" that also wipes storage (today the trash clears the canvas, which then saves the empty scene — same effect).
- Multiple named boards (would key by board id).

> Note: `test:code` (ESLint) is pre-existing red on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)