### PR TITLE
Feature: font family + size selection for text

### DIFF
--- a/src/Handlers/ToolsHandler/toolStyle.js
+++ b/src/Handlers/ToolsHandler/toolStyle.js
@@ -8,7 +8,25 @@ export const DEFAULT_STYLE = {
   strokeWidth: 3,
   strokeStyle: "solid", // solid | dashed | dotted
   fill: "transparent",
+  fontFamily: "Arial",
+  fontSize: 24,
 };
+
+export const FONT_FAMILIES = [
+  "Arial",
+  "Helvetica",
+  "Georgia",
+  "Times New Roman",
+  "Courier New",
+  "Verdana",
+  "Comic Sans MS",
+];
+
+export const FONT_SIZES = [
+  { label: "S", value: 16 },
+  { label: "M", value: 24 },
+  { label: "L", value: 36 },
+];
 
 export const STROKE_WIDTHS = [
   { label: "Thin", value: 2 },
@@ -55,3 +73,14 @@ export const toFabricStyle = (style = DEFAULT_STYLE) => ({
 // Fabric-ready style the tools should apply to a new object.
 export const resolveToolStyle = (canvas) =>
   canvas?.currentStyle || toFabricStyle(DEFAULT_STYLE);
+
+// Fabric-ready props for a new text object (colour is the stroke swatch).
+export const toTextStyle = (style = DEFAULT_STYLE) => ({
+  fill: style.stroke,
+  fontFamily: style.fontFamily,
+  fontSize: style.fontSize,
+});
+
+// Text style the Font tool should apply to a new text object.
+export const resolveTextStyle = (canvas) =>
+  canvas?.currentTextStyle || toTextStyle(DEFAULT_STYLE);

--- a/src/Handlers/ToolsHandler/tools/font.js
+++ b/src/Handlers/ToolsHandler/tools/font.js
@@ -1,6 +1,6 @@
 import { fabric } from "fabric";
 import { Tool } from "../toolGeneric";
-import { resolveToolStyle } from "../toolStyle";
+import { resolveTextStyle } from "../toolStyle";
 
 export class Font extends Tool {
   create(canvas, event) {
@@ -10,13 +10,12 @@ export class Font extends Tool {
 
 const createFont = (canvas, event) => {
   let pointer = canvas.getPointer(event.e);
-  // Text colour follows the chosen stroke colour (fabric text colour is fill).
+  // Colour, family and size come from the current text style (colour is the
+  // chosen stroke swatch, since fabric text colour is fill).
   let text = new fabric.IText("", {
     left: pointer.x,
     top: pointer.y,
-    fill: resolveToolStyle(canvas).stroke,
-    fontSize: 20,
-    fontFamily: "Arial",
+    ...resolveTextStyle(canvas),
   });
   canvas.add(text);
   text.enterEditing();

--- a/src/components/CanvasEditor/PropertiesPanel/PropertiesPanel.jsx
+++ b/src/components/CanvasEditor/PropertiesPanel/PropertiesPanel.jsx
@@ -7,7 +7,10 @@ import {
   FILL_SWATCHES,
   STROKE_WIDTHS,
   STROKE_STYLES,
+  FONT_FAMILIES,
+  FONT_SIZES,
   toFabricStyle,
+  toTextStyle,
 } from "../../../Handlers/ToolsHandler/toolStyle";
 import "./PropertiesPanel.scss";
 
@@ -51,6 +54,7 @@ const PropertiesPanel = () => {
   useEffect(() => {
     if (!canvas) return;
     canvas.currentStyle = toFabricStyle(style);
+    canvas.currentTextStyle = toTextStyle(style);
     if (canvas.freeDrawingBrush) {
       canvas.freeDrawingBrush.color = style.stroke;
     }
@@ -80,6 +84,10 @@ const PropertiesPanel = () => {
         : activeObject.fill === "" || activeObject.fill == null
           ? "transparent"
           : activeObject.fill,
+      fontFamily: text
+        ? activeObject.fontFamily || prev.fontFamily
+        : prev.fontFamily,
+      fontSize: text ? activeObject.fontSize || prev.fontSize : prev.fontSize,
     }));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeObject]);
@@ -95,7 +103,11 @@ const PropertiesPanel = () => {
       // For text the colour control drives the text colour (fill); other
       // controls don't meaningfully apply.
       if (isText(obj)) {
-        obj.set({ fill: nextStyle.stroke });
+        obj.set({
+          fill: nextStyle.stroke,
+          fontFamily: nextStyle.fontFamily,
+          fontSize: nextStyle.fontSize,
+        });
       } else if (obj.type === "group" && obj._objects) {
         // A group (e.g. the arrow) doesn't propagate style to its children,
         // so apply to each: line-like children take the stroke/width/dash;
@@ -130,6 +142,10 @@ const PropertiesPanel = () => {
 
   if (!activeObject && !STYLEABLE_TOOLS.has(activeTool)) return null;
 
+  // Text context shows font controls; shapes show fill/width/style.
+  const textContext =
+    isText(activeObject) || activeTool === TOOL_CONSTANTS.FONT;
+
   return (
     <div className="properties-panel upper">
       <div className="properties-panel__group">
@@ -160,89 +176,134 @@ const PropertiesPanel = () => {
         </div>
       </div>
 
-      <div className="properties-panel__group">
-        <span className="properties-panel__label">Fill</span>
-        <div className="properties-panel__swatches">
-          {FILL_SWATCHES.map((color) => (
-            <button
-              key={color}
-              type="button"
-              className={
-                style.fill === color
-                  ? "properties-panel__swatch active"
-                  : "properties-panel__swatch"
-              }
-              style={
-                color === "transparent" ? undefined : { backgroundColor: color }
-              }
-              data-none={color === "transparent" ? "true" : undefined}
-              onClick={() => updateStyle({ fill: color })}
-              aria-label={color === "transparent" ? "No fill" : `Fill ${color}`}
-            />
-          ))}
-          <Tooltip title="Custom fill color">
-            <input
-              type="color"
-              className="properties-panel__picker"
-              value={style.fill === "transparent" ? "#ffffff" : style.fill}
-              onChange={(e) => updateStyle({ fill: e.target.value })}
-            />
-          </Tooltip>
-        </div>
-      </div>
-
-      <div className="properties-panel__group">
-        <span className="properties-panel__label">Width</span>
-        <div className="properties-panel__row">
-          {STROKE_WIDTHS.map((w) => (
-            <button
-              key={w.value}
-              type="button"
-              className={
-                style.strokeWidth === w.value
-                  ? "properties-panel__btn active"
-                  : "properties-panel__btn"
-              }
-              onClick={() => updateStyle({ strokeWidth: w.value })}
+      {textContext ? (
+        <>
+          <div className="properties-panel__group">
+            <span className="properties-panel__label">Font</span>
+            <select
+              className="properties-panel__select"
+              value={style.fontFamily}
+              style={{ fontFamily: style.fontFamily }}
+              onChange={(e) => updateStyle({ fontFamily: e.target.value })}
             >
-              <span
-                className="properties-panel__width-preview"
-                style={{ height: `${w.value}px` }}
-              />
-            </button>
-          ))}
-        </div>
-      </div>
+              {FONT_FAMILIES.map((f) => (
+                <option key={f} value={f} style={{ fontFamily: f }}>
+                  {f}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="properties-panel__group">
+            <span className="properties-panel__label">Size</span>
+            <div className="properties-panel__row">
+              {FONT_SIZES.map((s) => (
+                <button
+                  key={s.value}
+                  type="button"
+                  className={
+                    style.fontSize === s.value
+                      ? "properties-panel__btn active"
+                      : "properties-panel__btn"
+                  }
+                  onClick={() => updateStyle({ fontSize: s.value })}
+                >
+                  {s.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="properties-panel__group">
+            <span className="properties-panel__label">Fill</span>
+            <div className="properties-panel__swatches">
+              {FILL_SWATCHES.map((color) => (
+                <button
+                  key={color}
+                  type="button"
+                  className={
+                    style.fill === color
+                      ? "properties-panel__swatch active"
+                      : "properties-panel__swatch"
+                  }
+                  style={
+                    color === "transparent"
+                      ? undefined
+                      : { backgroundColor: color }
+                  }
+                  data-none={color === "transparent" ? "true" : undefined}
+                  onClick={() => updateStyle({ fill: color })}
+                  aria-label={
+                    color === "transparent" ? "No fill" : `Fill ${color}`
+                  }
+                />
+              ))}
+              <Tooltip title="Custom fill color">
+                <input
+                  type="color"
+                  className="properties-panel__picker"
+                  value={style.fill === "transparent" ? "#ffffff" : style.fill}
+                  onChange={(e) => updateStyle({ fill: e.target.value })}
+                />
+              </Tooltip>
+            </div>
+          </div>
 
-      <div className="properties-panel__group">
-        <span className="properties-panel__label">Style</span>
-        <div className="properties-panel__row">
-          {STROKE_STYLES.map((s) => (
-            <button
-              key={s}
-              type="button"
-              className={
-                style.strokeStyle === s
-                  ? "properties-panel__btn active"
-                  : "properties-panel__btn"
-              }
-              onClick={() => updateStyle({ strokeStyle: s })}
-            >
-              <span
-                className="properties-panel__style-preview"
-                style={{
-                  borderTopStyle:
-                    s === "solid"
-                      ? "solid"
-                      : s === "dashed"
-                        ? "dashed"
-                        : "dotted",
-                }}
-              />
-            </button>
-          ))}
-        </div>
-      </div>
+          <div className="properties-panel__group">
+            <span className="properties-panel__label">Width</span>
+            <div className="properties-panel__row">
+              {STROKE_WIDTHS.map((w) => (
+                <button
+                  key={w.value}
+                  type="button"
+                  className={
+                    style.strokeWidth === w.value
+                      ? "properties-panel__btn active"
+                      : "properties-panel__btn"
+                  }
+                  onClick={() => updateStyle({ strokeWidth: w.value })}
+                >
+                  <span
+                    className="properties-panel__width-preview"
+                    style={{ height: `${w.value}px` }}
+                  />
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="properties-panel__group">
+            <span className="properties-panel__label">Style</span>
+            <div className="properties-panel__row">
+              {STROKE_STYLES.map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  className={
+                    style.strokeStyle === s
+                      ? "properties-panel__btn active"
+                      : "properties-panel__btn"
+                  }
+                  onClick={() => updateStyle({ strokeStyle: s })}
+                >
+                  <span
+                    className="properties-panel__style-preview"
+                    style={{
+                      borderTopStyle:
+                        s === "solid"
+                          ? "solid"
+                          : s === "dashed"
+                            ? "dashed"
+                            : "dotted",
+                    }}
+                  />
+                </button>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/CanvasEditor/PropertiesPanel/PropertiesPanel.scss
+++ b/src/components/CanvasEditor/PropertiesPanel/PropertiesPanel.scss
@@ -70,6 +70,17 @@
     cursor: pointer;
   }
 
+  &__select {
+    width: 100%;
+    padding: 5px 8px;
+    border: 1px solid var(--light-border-color);
+    border-radius: 6px;
+    background: white;
+    font-size: var(--default-font-size);
+    color: #1e1e1e;
+    cursor: pointer;
+  }
+
   &__row {
     display: flex;
     gap: 6px;


### PR DESCRIPTION
## What
Adds **Font family** (dropdown) and **Size** (S/M/L) controls to the properties panel for text. When the Text tool is active or a text object is selected, the panel shows **Stroke (colour) + Font + Size** and hides the shape-only Fill/Width/Style controls.

- New text picks up the chosen family/size (and colour from the Stroke swatch).
- Selecting a text loads its font into the panel; changing family/size restyles it live.

## How
- `toolStyle.js`: `DEFAULT_STYLE` gains `fontFamily`/`fontSize`; adds `FONT_FAMILIES`, `FONT_SIZES`, and `toTextStyle()`/`resolveTextStyle()`.
- `font.js` reads the current text style (colour + family + size) instead of hardcoding Arial/20.
- `PropertiesPanel` mirrors `canvas.currentTextStyle`, renders the Font/Size groups in text context, and loads/applies a selected text's font.

## Verified
New text created as Georgia/36 (chosen); selecting it and switching to Courier New updated it. Screenshot: panel shows Font + Size for text, Fill/Width/Style for shapes.

## Note
Fonts are web-safe families (Arial, Helvetica, Georgia, Times New Roman, Courier New, Verdana, Comic Sans MS) — no web-font loading. A hand-drawn font (excalidraw's Virgil) could be added later by bundling the font file.

> Note: `test:code` (ESLint) is pre-existing red on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)