### PR TITLE
Fix: persistence — flush pending save on close, without clobbering other tabs

### DIFF
--- a/src/Handlers/EventHandlers/persistenceHandler.js
+++ b/src/Handlers/EventHandlers/persistenceHandler.js
@@ -37,6 +37,20 @@ function PersistenceHandler() {
       }, SAVE_DEBOUNCE_MS);
     };
 
+    // Save immediately (cancelling any pending debounce) when the tab is
+    // hidden or closing, so a change made within the debounce window isn't
+    // lost. Best-effort — the write may not finish if the tab is killed.
+    const flushSave = () => {
+      if (saveTimer.current) {
+        clearTimeout(saveTimer.current);
+        saveTimer.current = null;
+      }
+      saveScene(canvas.toJSON());
+    };
+    const onVisibility = () => {
+      if (document.visibilityState === "hidden") flushSave();
+    };
+
     const events = [
       "object:added",
       "object:modified",
@@ -45,11 +59,15 @@ function PersistenceHandler() {
       "background:changed", // fired by the background-color tool
     ];
     events.forEach((ev) => canvas.on(ev, scheduleSave));
+    window.addEventListener("beforeunload", flushSave);
+    document.addEventListener("visibilitychange", onVisibility);
 
     return () => {
       disposed = true;
       if (saveTimer.current) clearTimeout(saveTimer.current);
       events.forEach((ev) => canvas.off(ev, scheduleSave));
+      window.removeEventListener("beforeunload", flushSave);
+      document.removeEventListener("visibilitychange", onVisibility);
     };
   }, [canvas]);
 }

--- a/src/Handlers/EventHandlers/persistenceHandler.js
+++ b/src/Handlers/EventHandlers/persistenceHandler.js
@@ -34,17 +34,19 @@ function PersistenceHandler() {
       if (saveTimer.current) clearTimeout(saveTimer.current);
       saveTimer.current = setTimeout(() => {
         saveScene(canvas.toJSON());
+        // Mark clean once written, so a later flush knows nothing is pending.
+        saveTimer.current = null;
       }, SAVE_DEBOUNCE_MS);
     };
 
-    // Save immediately (cancelling any pending debounce) when the tab is
-    // hidden or closing, so a change made within the debounce window isn't
-    // lost. Best-effort — the write may not finish if the tab is killed.
+    // Flush a *pending* change immediately when the tab is hidden/closing, so a
+    // change made within the debounce window isn't lost. Crucially, do nothing
+    // when there's no pending save — otherwise an idle tab would overwrite the
+    // shared record with its stale scene and clobber edits made in another tab.
     const flushSave = () => {
-      if (saveTimer.current) {
-        clearTimeout(saveTimer.current);
-        saveTimer.current = null;
-      }
+      if (!saveTimer.current) return;
+      clearTimeout(saveTimer.current);
+      saveTimer.current = null;
       saveScene(canvas.toJSON());
     };
     const onVisibility = () => {


### PR DESCRIPTION
Follow-up to the IndexedDB persistence (#85).

## 1. Flush a pending save on tab hide/close
The save is debounced (800ms); closing/switching the tab right after a change could lose it. Flush immediately on `beforeunload` and on `visibilitychange → hidden`.

## 2. Don't let an idle tab clobber another tab (multi-tab)
Two tabs share one IndexedDB record. The naive flush wrote the tab's in-memory scene unconditionally — so reloading an **idle** tab (reload fires `beforeunload`) overwrote edits another tab had saved, and the reload then showed the stale scene.

Fix: only flush when a save is **actually pending** (debounce timer set); clear the timer once the debounced save completes. An idle tab writes nothing on unload, so its reload picks up the latest scene.

## Verified (two tabs, on localhost)
- Tab A draws a shape → saves.
- Tab B (duplicate) loads it, adds a shape → IDB has 2.
- **Reload Tab A → now shows 2** (previously reverted to Tab A's stale 1 and overwrote IDB back to 1).
- Also: a change made within the debounce window is still flushed on close.

## Known limitation (not fixed here)
If **both** tabs have unsaved edits concurrently, it's still last-writer-wins — true live multi-tab sync would need a `BroadcastChannel`. Out of scope for this fix; can follow up if you want real-time multi-tab.

> Note: `test:code` (ESLint) is pre-existing red on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)