### PR TITLE
Feature: layering controls (bring to front/back/forward/backward)

### DIFF
--- a/src/components/CanvasEditor/PropertiesPanel/PropertiesPanel.jsx
+++ b/src/components/CanvasEditor/PropertiesPanel/PropertiesPanel.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from "react";
 import { Tooltip } from "@mui/material";
+import { BringToFront, SendToBack, ChevronUp, ChevronDown } from "lucide-react";
 import { useMenuContext, useCanvasContext } from "../../../hooks";
 import { TOOL_CONSTANTS } from "../../../constants";
 import {
@@ -138,6 +139,24 @@ const PropertiesPanel = () => {
     styleRef.current = next;
     setStyle(next);
     applyToActive(next);
+  };
+
+  // Reorder the selection's z-index. sendToBack/sendBackwards process in
+  // reverse so a multi-selection keeps its internal stacking order.
+  const reorder = (method) => {
+    if (!canvas || !activeObject) return;
+    const targets =
+      activeObject.type === "activeSelection"
+        ? activeObject.getObjects()
+        : [activeObject];
+    const ordered =
+      method === "sendToBack" || method === "sendBackwards"
+        ? [...targets].reverse()
+        : targets;
+    ordered.forEach((obj) => canvas[method](obj));
+    canvas.requestRenderAll();
+    // Record one history entry (and trigger persistence) for the reorder.
+    canvas.fire("object:modified", { target: activeObject });
   };
 
   if (!activeObject && !STYLEABLE_TOOLS.has(activeTool)) return null;
@@ -303,6 +322,50 @@ const PropertiesPanel = () => {
             </div>
           </div>
         </>
+      )}
+
+      {activeObject && (
+        <div className="properties-panel__group">
+          <span className="properties-panel__label">Layer</span>
+          <div className="properties-panel__row">
+            <Tooltip title="Send to back">
+              <button
+                type="button"
+                className="properties-panel__btn"
+                onClick={() => reorder("sendToBack")}
+              >
+                <SendToBack size={16} />
+              </button>
+            </Tooltip>
+            <Tooltip title="Send backward">
+              <button
+                type="button"
+                className="properties-panel__btn"
+                onClick={() => reorder("sendBackwards")}
+              >
+                <ChevronDown size={16} />
+              </button>
+            </Tooltip>
+            <Tooltip title="Bring forward">
+              <button
+                type="button"
+                className="properties-panel__btn"
+                onClick={() => reorder("bringForward")}
+              >
+                <ChevronUp size={16} />
+              </button>
+            </Tooltip>
+            <Tooltip title="Bring to front">
+              <button
+                type="button"
+                className="properties-panel__btn"
+                onClick={() => reorder("bringToFront")}
+              >
+                <BringToFront size={16} />
+              </button>
+            </Tooltip>
+          </div>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## What
Objects stack strictly by creation order and there was no way to reorder — so a shape drawn *after* your text (or any lower object) sat on top with no fix. Adds a **Layer** group to the properties panel (shown when an object is selected):

- **Send to back** · **Send backward** · **Bring forward** · **Bring to front**

backed by fabric's `sendToBack` / `sendBackwards` / `bringForward` / `bringToFront`.

## Details
- Reorder fires `object:modified`, so it's captured by **undo history** and **persisted** (IndexedDB).
- Multi-selections reorder as a group; the back-directions process in reverse so the selection keeps its internal stacking order.

## Verified
Two overlapping shapes: bringing the lower one to front reorders it above the other and renders on top; send-to-back restores it. The Layer group only appears when something is selected.

> Note: `test:code` (ESLint) is pre-existing red on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)