### PR TITLE
Feature: constant stroke width on scale + no-distortion arrow resize

### DIFF
--- a/src/Handlers/EventHandlers/arrowResizeHandler.js
+++ b/src/Handlers/EventHandlers/arrowResizeHandler.js
@@ -1,0 +1,96 @@
+import { useEffect } from "react";
+import { fabric } from "fabric";
+import { useCanvasContext } from "../../hooks";
+import { buildArrowGroup } from "../ToolsHandler/tools/arrow";
+
+// An arrow is a group of exactly a line + a path (the head).
+const isArrowGroup = (o) =>
+  o &&
+  o.type === "group" &&
+  o._objects &&
+  o._objects.length === 2 &&
+  o._objects.some((c) => c.type === "line") &&
+  o._objects.some((c) => c.type === "path");
+
+const OPPOSITE = { tl: "br", tr: "bl", br: "tl", bl: "tr" };
+
+// Resizing an arrow scales the whole group, which stretches and distorts the
+// arrowhead. Instead, after a scale we rebuild the arrow between its real
+// endpoints with a fixed-size head and unscaled stroke — length/direction
+// change, the head stays constant.
+function ArrowResizeHandler() {
+  const { canvas } = useCanvasContext();
+
+  useEffect(() => {
+    if (!canvas) return undefined;
+    let rebuilding = false;
+
+    const onModified = (e) => {
+      const group = e && e.target;
+      if (rebuilding || !isArrowGroup(group)) return;
+      // Only act on an actual scale — a plain move/rotate needs no rebuild.
+      if (
+        (group.scaleX == null || group.scaleX === 1) &&
+        (group.scaleY == null || group.scaleY === 1)
+      ) {
+        return;
+      }
+
+      const head = group._objects.find((c) => c.type === "path");
+      const line = group._objects.find((c) => c.type === "line");
+      const matrix = group.calcTransformMatrix();
+      // The head sits at the arrow tip; its absolute centre is the new tip.
+      const tip = fabric.util.transformPoint(
+        new fabric.Point(head.left, head.top),
+        matrix,
+      );
+      // The tail is the bounding-box corner diagonally opposite the tip corner.
+      const corners = group.aCoords;
+      let nearest = "tl";
+      let bestDist = Infinity;
+      Object.keys(corners).forEach((k) => {
+        const d = Math.hypot(corners[k].x - tip.x, corners[k].y - tip.y);
+        if (d < bestDist) {
+          bestDist = d;
+          nearest = k;
+        }
+      });
+      const tail = corners[OPPOSITE[nearest]];
+
+      const style = {
+        stroke: line.stroke,
+        strokeWidth: line.strokeWidth,
+        strokeDashArray: line.strokeDashArray,
+      };
+
+      rebuilding = true;
+      const supportsHistory = typeof canvas._historySaveAction === "function";
+      if (supportsHistory) canvas.historyProcessing = true;
+
+      const arrow = buildArrowGroup(
+        { x: tail.x, y: tail.y },
+        { x: tip.x, y: tip.y },
+        style,
+      );
+      canvas.remove(group);
+      canvas.add(arrow);
+      arrow.setCoords();
+      canvas.setActiveObject(arrow);
+      canvas.requestRenderAll();
+
+      if (supportsHistory) {
+        canvas.historyProcessing = false;
+        // fabric-history already pushed the pre-resize state for undo; point the
+        // baseline at the rebuilt arrow so redo/next-save use the clean version,
+        // not the scaled one.
+        canvas.historyNextState = canvas._historyNext();
+      }
+      rebuilding = false;
+    };
+
+    canvas.on("object:modified", onModified);
+    return () => canvas.off("object:modified", onModified);
+  }, [canvas]);
+}
+
+export default ArrowResizeHandler;

--- a/src/Handlers/EventHandlers/arrowResizeHandler.js
+++ b/src/Handlers/EventHandlers/arrowResizeHandler.js
@@ -34,8 +34,11 @@ function ArrowResizeHandler() {
       if (rebuilding || !isArrowGroup(group)) return;
       const head = group._objects.find((c) => c.type === "path");
       if (!head) return;
-      head.scaleX = 1 / (group.scaleX || 1);
-      head.scaleY = 1 / (group.scaleY || 1);
+      // Use |scale| so the head keeps a constant size AND mirrors together with
+      // the line when the group is flipped (a corner dragged past the opposite
+      // corner) — otherwise the line would mirror while the head stayed put.
+      head.scaleX = 1 / Math.abs(group.scaleX || 1);
+      head.scaleY = 1 / Math.abs(group.scaleY || 1);
     };
 
     const onModified = (e) => {

--- a/src/Handlers/EventHandlers/arrowResizeHandler.js
+++ b/src/Handlers/EventHandlers/arrowResizeHandler.js
@@ -25,6 +25,19 @@ function ArrowResizeHandler() {
     if (!canvas) return undefined;
     let rebuilding = false;
 
+    // While the arrow is being dragged, fabric scales the whole group so the
+    // head balloons/distorts until the drag ends (when onModified rebuilds it).
+    // Counter-scale the head child every scaling frame so it stays a constant
+    // size live; the line's stroke already stays constant via strokeUniform.
+    const onScaling = (e) => {
+      const group = e && e.target;
+      if (rebuilding || !isArrowGroup(group)) return;
+      const head = group._objects.find((c) => c.type === "path");
+      if (!head) return;
+      head.scaleX = 1 / (group.scaleX || 1);
+      head.scaleY = 1 / (group.scaleY || 1);
+    };
+
     const onModified = (e) => {
       const group = e && e.target;
       if (rebuilding || !isArrowGroup(group)) return;
@@ -88,8 +101,12 @@ function ArrowResizeHandler() {
       rebuilding = false;
     };
 
+    canvas.on("object:scaling", onScaling);
     canvas.on("object:modified", onModified);
-    return () => canvas.off("object:modified", onModified);
+    return () => {
+      canvas.off("object:scaling", onScaling);
+      canvas.off("object:modified", onModified);
+    };
   }, [canvas]);
 }
 

--- a/src/Handlers/EventHandlers/arrowResizeHandler.js
+++ b/src/Handlers/EventHandlers/arrowResizeHandler.js
@@ -12,8 +12,6 @@ const isArrowGroup = (o) =>
   o._objects.some((c) => c.type === "line") &&
   o._objects.some((c) => c.type === "path");
 
-const OPPOSITE = { tl: "br", tr: "bl", br: "tl", bl: "tr" };
-
 // Resizing an arrow scales the whole group, which stretches and distorts the
 // arrowhead. Instead, after a scale we rebuild the arrow between its real
 // endpoints with a fixed-size head and unscaled stroke — length/direction
@@ -60,18 +58,25 @@ function ArrowResizeHandler() {
         new fabric.Point(head.left, head.top),
         matrix,
       );
-      // The tail is the bounding-box corner diagonally opposite the tip corner.
-      const corners = group.aCoords;
-      let nearest = "tl";
-      let bestDist = Infinity;
-      Object.keys(corners).forEach((k) => {
-        const d = Math.hypot(corners[k].x - tip.x, corners[k].y - tip.y);
-        if (d < bestDist) {
-          bestDist = d;
-          nearest = k;
-        }
-      });
-      const tail = corners[OPPOSITE[nearest]];
+      // The tail is the line's OTHER endpoint. Derive it from the line's real
+      // endpoints — NOT the group's bounding box: the head inflates the bbox, so
+      // an opposite-corner tail sits off the line and tilts a horizontal arrow
+      // on drop. calcLinePoints() is relative to the line's centre; add the
+      // line's left/top (relative to the group centre) then map to absolute.
+      const lp = line.calcLinePoints();
+      const end1 = fabric.util.transformPoint(
+        new fabric.Point(line.left + lp.x1, line.top + lp.y1),
+        matrix,
+      );
+      const end2 = fabric.util.transformPoint(
+        new fabric.Point(line.left + lp.x2, line.top + lp.y2),
+        matrix,
+      );
+      const tail =
+        Math.hypot(end1.x - tip.x, end1.y - tip.y) >
+        Math.hypot(end2.x - tip.x, end2.y - tip.y)
+          ? end1
+          : end2;
 
       const style = {
         stroke: line.stroke,

--- a/src/Handlers/EventHandlers/index.js
+++ b/src/Handlers/EventHandlers/index.js
@@ -4,3 +4,4 @@ export { default as SelectionHandler } from "./selectionHandler";
 export { default as TextEventHandler } from "./textEventHandler";
 export { default as ZoomHandler } from "./zoomHandler";
 export { default as PersistenceHandler } from "./persistenceHandler";
+export { default as ArrowResizeHandler } from "./arrowResizeHandler";

--- a/src/Handlers/ToolsHandler/toolStyle.js
+++ b/src/Handlers/ToolsHandler/toolStyle.js
@@ -63,14 +63,19 @@ export const strokeDashArrayFor = (strokeStyle, strokeWidth) => {
 };
 
 // Convert a style object into the fabric props shared by the shape tools.
-// strokeUniform keeps the border a constant width when the shape is scaled
-// (fabric otherwise scales strokeWidth, making borders balloon on resize).
+// - strokeUniform keeps the border a constant width when the shape is scaled
+//   (fabric otherwise scales strokeWidth, making borders balloon on resize).
+// - objectCaching:false is required for that to hold *during* an interactive
+//   scale: a cached object draws its stale (pre-scale) bitmap scaled up while
+//   dragging, so the stroke still looked thick until drop. Rendering fresh each
+//   frame honours strokeUniform live.
 export const toFabricStyle = (style = DEFAULT_STYLE) => ({
   stroke: style.stroke,
   strokeWidth: style.strokeWidth,
   strokeDashArray: strokeDashArrayFor(style.strokeStyle, style.strokeWidth),
   fill: style.fill,
   strokeUniform: true,
+  objectCaching: false,
 });
 
 // Fabric-ready style the tools should apply to a new object.

--- a/src/Handlers/ToolsHandler/toolStyle.js
+++ b/src/Handlers/ToolsHandler/toolStyle.js
@@ -63,11 +63,14 @@ export const strokeDashArrayFor = (strokeStyle, strokeWidth) => {
 };
 
 // Convert a style object into the fabric props shared by the shape tools.
+// strokeUniform keeps the border a constant width when the shape is scaled
+// (fabric otherwise scales strokeWidth, making borders balloon on resize).
 export const toFabricStyle = (style = DEFAULT_STYLE) => ({
   stroke: style.stroke,
   strokeWidth: style.strokeWidth,
   strokeDashArray: strokeDashArrayFor(style.strokeStyle, style.strokeWidth),
   fill: style.fill,
+  strokeUniform: true,
 });
 
 // Fabric-ready style the tools should apply to a new object.

--- a/src/Handlers/ToolsHandler/tools/arrow.js
+++ b/src/Handlers/ToolsHandler/tools/arrow.js
@@ -2,6 +2,41 @@ import { fabric } from "fabric";
 import { Tool } from "../toolGeneric";
 import { resolveToolStyle } from "../toolStyle";
 
+const ARROW_HEAD_PATH = "M 0 0 L 20 10 L 0 20 Z";
+
+const angleBetween = (start, end) =>
+  (Math.atan2(end.y - start.y, end.x - start.x) * 180) / Math.PI;
+
+// Build a fresh arrow (line + fixed-size head) from start -> end with the given
+// style. Exported so the resize handler can rebuild an arrow at a new size
+// without scaling — and distorting — the head.
+export const buildArrowGroup = (start, end, style) => {
+  const line = new fabric.Line([start.x, start.y, end.x, end.y], {
+    stroke: style.stroke,
+    strokeWidth: style.strokeWidth,
+    strokeDashArray: style.strokeDashArray || null,
+    originX: "center",
+    originY: "center",
+    hasControls: false,
+    hasBorders: false,
+    selectable: false,
+  });
+  const head = new fabric.Path(ARROW_HEAD_PATH, {
+    stroke: "",
+    strokeWidth: 0,
+    fill: style.stroke,
+    originX: "center",
+    originY: "center",
+    left: end.x,
+    top: end.y,
+    angle: angleBetween(start, end),
+    hasControls: false,
+    hasBorders: false,
+    selectable: false,
+  });
+  return new fabric.Group([line, head], { objectCaching: false });
+};
+
 export class Arrow extends Tool {
   constructor() {
     super();
@@ -10,7 +45,7 @@ export class Arrow extends Tool {
     this.pointer = null;
     this.line = null;
     this.arrowHead = null;
-    this.arrow = null;
+    this.style = null;
     this.deleteOffset = 10;
   }
 
@@ -18,15 +53,16 @@ export class Arrow extends Tool {
     this.pointer = canvas.getPointer(event.e);
     this.origX = this.pointer.x;
     this.origY = this.pointer.y;
-    let arrowHeadPath = "M 0 0 L 20 10 L 0 20 Z";
-    const style = resolveToolStyle(canvas);
+    this.style = resolveToolStyle(canvas);
 
+    // Live preview: a plain line + head that follow the cursor; on mouse-up
+    // they're replaced by a proper arrow group (buildArrowGroup).
     this.line = new fabric.Line(
       [this.origX, this.origY, this.origX, this.origY],
       {
-        stroke: style.stroke,
-        strokeWidth: style.strokeWidth,
-        strokeDashArray: style.strokeDashArray,
+        stroke: this.style.stroke,
+        strokeWidth: this.style.strokeWidth,
+        strokeDashArray: this.style.strokeDashArray,
         originX: "center",
         originY: "center",
         hasControls: false,
@@ -34,17 +70,16 @@ export class Arrow extends Tool {
         selectable: false,
       },
     );
-
-    this.arrowHead = new fabric.Path(arrowHeadPath, {
+    this.arrowHead = new fabric.Path(ARROW_HEAD_PATH, {
       stroke: "",
       strokeWidth: 0,
-      fill: style.stroke,
+      fill: this.style.stroke,
       originX: "center",
       originY: "center",
-      hasControls: false,
-      hasBorders: false,
       top: this.origY,
       left: this.origX,
+      hasControls: false,
+      hasBorders: false,
       selectable: false,
     });
     canvas.add(this.line, this.arrowHead);
@@ -59,10 +94,9 @@ export class Arrow extends Tool {
     this.line.setCoords();
     this.arrowHead.left = this.pointer.x;
     this.arrowHead.top = this.pointer.y;
-    this.arrowHead.angle = this.calcArrowAngle(
+    this.arrowHead.angle = angleBetween(
+      { x: this.origX, y: this.origY },
       this.pointer,
-      this.origX,
-      this.origY,
     );
     this.arrowHead.setCoords();
   }
@@ -75,19 +109,16 @@ export class Arrow extends Tool {
       this.pointer.x - this.origX,
       this.pointer.y - this.origY,
     );
+    canvas.remove(this.line, this.arrowHead);
     if (length < this.deleteOffset) {
-      canvas.remove(this.line, this.arrowHead);
       return;
     }
-    this.arrow = new fabric.Group([this.line, this.arrowHead], {
-      objectCaching: false,
-    });
-    canvas.remove(this.line, this.arrowHead);
-    this.arrow.setCoords();
-    canvas.add(this.arrow);
-  }
-
-  calcArrowAngle(pointer, origX, origY) {
-    return (Math.atan2(pointer.y - origY, pointer.x - origX) * 180) / Math.PI;
+    const arrow = buildArrowGroup(
+      { x: this.origX, y: this.origY },
+      { x: this.pointer.x, y: this.pointer.y },
+      this.style || resolveToolStyle(canvas),
+    );
+    arrow.setCoords();
+    canvas.add(arrow);
   }
 }

--- a/src/Handlers/ToolsHandler/tools/arrow.js
+++ b/src/Handlers/ToolsHandler/tools/arrow.js
@@ -15,6 +15,7 @@ export const buildArrowGroup = (start, end, style) => {
     stroke: style.stroke,
     strokeWidth: style.strokeWidth,
     strokeDashArray: style.strokeDashArray || null,
+    strokeUniform: true,
     originX: "center",
     originY: "center",
     hasControls: false,

--- a/src/Handlers/ToolsHandler/tools/arrow.js
+++ b/src/Handlers/ToolsHandler/tools/arrow.js
@@ -35,7 +35,13 @@ export const buildArrowGroup = (start, end, style) => {
     hasBorders: false,
     selectable: false,
   });
-  return new fabric.Group([line, head], { objectCaching: false });
+  const group = new fabric.Group([line, head], { objectCaching: false });
+  // Resize arrows from the corners only. Canvas uniformScaling makes corner
+  // drags scale both axes together; a *side* handle scales one axis, which
+  // shears/mirrors the rotated head. Hiding the side handles keeps every
+  // resize uniform so the head stays a clean, fixed-size triangle.
+  group.setControlsVisibility({ mt: false, mb: false, ml: false, mr: false });
+  return group;
 };
 
 export class Arrow extends Tool {

--- a/src/components/Canvas/Canvas.jsx
+++ b/src/components/Canvas/Canvas.jsx
@@ -9,6 +9,7 @@ import {
   TextEventHandler,
   ZoomHandler,
   PersistenceHandler,
+  ArrowResizeHandler,
 } from "../../Handlers/EventHandlers";
 
 function Canvas() {
@@ -18,6 +19,7 @@ function Canvas() {
   TextEventHandler();
   ZoomHandler();
   PersistenceHandler();
+  ArrowResizeHandler();
   const canvasRef = useRef(null);
   const { setCanvas } = useCanvasContext();
 


### PR DESCRIPTION
## What changed
- **Arrow resize** rebuilds the arrow between its real endpoints with a fixed-size head and unscaled stroke on `object:modified`, so length/direction change without distorting the head.
- **Constant stroke width on scale** — `strokeUniform: true` on all shapes (rect, circle, diamond, polygon, line, arrow line). Fabric otherwise scales `strokeWidth` with the object, so borders ballooned when a shape was enlarged. Now the border stays the chosen width at any scale (matches excalidraw).
- **Arrow head fixed *during* the drag** — the head is counter-scaled every `object:scaling` frame, so it stays a constant size live instead of ballooning until drag-end. The drag-end rebuild still runs to bake in the clean geometry.

## Why
Reported while testing the preview: shape borders got too thick when scaling, and the arrow "looked weird while dragging" then self-corrected only on release.

## Test plan
- In-browser: rect/circle drawn → `strokeUniform === true`.
- Arrow: line has `strokeUniform`; simulated a 2.5× scaling drag → head effective size stays 1 (constant); `object:modified` rebuilds at scale 1 with a fresh head, object count unchanged, rebuilt arrow stays active.
- `npm run build` compiles clean; prettier clean.