### PR TITLE
Feature: light/dark theme toggle

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3,9 +3,10 @@ html {
   margin: 0;
   height: 100%;
   overflow: hidden;
-  /* Explicit light canvas so the board doesn't inherit the OS/browser theme
-     (which left shapes invisible on a dark-mode default). */
-  background: #ffffff;
+  /* The board background. Driven by the theme token (light #ffffff / dark
+     #121212); the fabric canvas is transparent so this shows through, unless
+     the user sets an explicit canvas background via the background-color tool. */
+  background: var(--app-bg, #ffffff);
 }
 
 canvas {

--- a/src/App.js
+++ b/src/App.js
@@ -1,17 +1,44 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { CanvasEditor } from "./components/CanvasEditor";
-import { StyledEngineProvider } from "@mui/material/styles";
-import { CanvasProvider, MenuProvider } from "./contexts";
+import {
+  StyledEngineProvider,
+  ThemeProvider as MuiThemeProvider,
+  createTheme,
+} from "@mui/material/styles";
+import { CanvasProvider, MenuProvider, ThemeProvider } from "./contexts";
+import { useThemeContext } from "./hooks";
+import { getInitialTheme, applyTheme } from "./utils/theme";
 import "./App.css";
 
-function App() {
+// Set the theme attribute before first paint so the board/chrome don't flash
+// the light theme on load for a dark-mode user.
+applyTheme(getInitialTheme());
+
+// Bridge our theme into MUI so its portalled bits (Dialog, Menu, Tooltip,
+// Divider) match the light/dark chrome instead of staying stuck on light.
+const ThemedApp = () => {
+  const { theme } = useThemeContext();
+  const muiTheme = useMemo(
+    () => createTheme({ palette: { mode: theme } }),
+    [theme],
+  );
   return (
-    <StyledEngineProvider injectFirst>
+    <MuiThemeProvider theme={muiTheme}>
       <CanvasProvider>
         <MenuProvider>
           <CanvasEditor />
         </MenuProvider>
       </CanvasProvider>
+    </MuiThemeProvider>
+  );
+};
+
+function App() {
+  return (
+    <StyledEngineProvider injectFirst>
+      <ThemeProvider>
+        <ThemedApp />
+      </ThemeProvider>
     </StyledEngineProvider>
   );
 }

--- a/src/components/CanvasEditor/Footer/Footer.jsx
+++ b/src/components/CanvasEditor/Footer/Footer.jsx
@@ -1,10 +1,12 @@
 import ZoomPanel from "./Zoom/ZoomPanel";
 import "./Footer.scss";
 import Help from "./Help/Help";
+import ThemeToggle from "../ThemeToggle/ThemeToggle";
 
 const Footer = () => {
   return (
     <div className="footer">
+      <ThemeToggle />
       <ZoomPanel />
       <Help />
     </div>

--- a/src/components/CanvasEditor/Footer/Help/Help.scss
+++ b/src/components/CanvasEditor/Footer/Help/Help.scss
@@ -6,7 +6,7 @@
 
   &__icon {
     display: flex;
-    background-color: white;
+    background-color: var(--surface-bg);
     border-radius: var(--default-border-radius);
     box-shadow: 0 0 var(--default-shadow-blur) var(--default-shadow-color);
     width: 100%;
@@ -22,7 +22,7 @@
     text-transform: none;
     font-weight: bold;
     font-size: var(--default-font-size);
-    color: #000;
+    color: var(--surface-text);
     padding: 5px 20px;
     background-color: var(--default-theme-color);
     border: 1px solid var(--button-borderColor);

--- a/src/components/CanvasEditor/Header/LeftMenu/LeftMenu_social.scss
+++ b/src/components/CanvasEditor/Header/LeftMenu/LeftMenu_social.scss
@@ -12,7 +12,7 @@
     text-transform: none;
     font-weight: bold;
     font-size: var(--default-font-size);
-    color: #000;
+    color: var(--surface-text);
     background-color: var(--default-theme-color);
     border: 1px solid var(--button-borderColor);
     &:hover {

--- a/src/components/CanvasEditor/Header/LeftMenu/Leftmenu.scss
+++ b/src/components/CanvasEditor/Header/LeftMenu/Leftmenu.scss
@@ -4,7 +4,7 @@
 
   &__icon {
     border-radius: 5px;
-    background-color: #f5f5f5;
+    background-color: var(--surface-bg);
     box-shadow: 0 0 5px rgba(0, 0, 0, 0.25);
   }
 }

--- a/src/components/CanvasEditor/Header/Menu/menu.scss
+++ b/src/components/CanvasEditor/Header/Menu/menu.scss
@@ -8,7 +8,7 @@
   &__inner-container {
     display: flex;
     border-radius: 10px;
-    background-color: white;
+    background-color: var(--surface-bg);
     box-shadow: 0 0 var(--default-shadow-blur) var(--default-shadow-color);
     padding: 5px;
 
@@ -22,7 +22,7 @@
     margin: 0 5px;
     padding: 8px 10px;
     border: none;
-    color: black;
+    color: var(--surface-text);
     cursor: pointer;
 
     &:hover {

--- a/src/components/CanvasEditor/Header/RightMenu/Save.scss
+++ b/src/components/CanvasEditor/Header/RightMenu/Save.scss
@@ -9,16 +9,16 @@
     box-shadow: 0 0 var(--default-shadow-blur) var(--default-shadow-color);
 
     &-button {
-      background-color: #fff;
-      border: 1px solid #fff;
+      background-color: var(--surface-bg);
+      border: 1px solid var(--surface-bg);
       text-transform: none;
       font-size: var(--secondary-font-size);
       box-shadow: none;
-      color: #000;
+      color: var(--surface-text);
 
       &:hover {
         background-color: var(--default-theme-color);
-        border: 1px solid #fff;
+        border: 1px solid var(--surface-bg);
         box-shadow: none;
       }
     }

--- a/src/components/CanvasEditor/PropertiesPanel/PropertiesPanel.scss
+++ b/src/components/CanvasEditor/PropertiesPanel/PropertiesPanel.scss
@@ -11,7 +11,7 @@
   gap: 14px;
   padding: 14px;
   width: 200px;
-  background-color: white;
+  background-color: var(--surface-bg);
   border-radius: var(--default-border-radius);
   box-shadow: 0 0 var(--default-shadow-blur) var(--default-shadow-color);
 
@@ -24,7 +24,7 @@
   &__label {
     font-size: var(--default-font-size);
     font-weight: 600;
-    color: #495057;
+    color: var(--surface-muted);
   }
 
   &__swatches {
@@ -49,7 +49,7 @@
 
     // "No fill" swatch: white with a red diagonal strike.
     &[data-none="true"] {
-      background: white;
+      background: var(--surface-input-bg);
       background-image: linear-gradient(
         to top right,
         transparent 45%,
@@ -75,9 +75,9 @@
     padding: 5px 8px;
     border: 1px solid var(--light-border-color);
     border-radius: 6px;
-    background: white;
+    background: var(--surface-input-bg);
     font-size: var(--default-font-size);
-    color: #1e1e1e;
+    color: var(--surface-text);
     cursor: pointer;
   }
 
@@ -94,7 +94,7 @@
     height: 28px;
     border: 1px solid var(--light-border-color);
     border-radius: 6px;
-    background: white;
+    background: var(--surface-input-bg);
     cursor: pointer;
 
     &.active {
@@ -105,14 +105,14 @@
 
   &__width-preview {
     width: 22px;
-    background-color: #1e1e1e;
+    background-color: var(--surface-text);
     border-radius: 2px;
   }
 
   &__style-preview {
     width: 24px;
     border-top-width: 2px;
-    border-top-color: #1e1e1e;
+    border-top-color: var(--surface-text);
     display: inline-block;
   }
 }

--- a/src/components/CanvasEditor/ThemeToggle/ThemeToggle.jsx
+++ b/src/components/CanvasEditor/ThemeToggle/ThemeToggle.jsx
@@ -35,7 +35,7 @@ const ThemeToggle = () => {
 
   const Icon = isDark ? Sun : Moon;
   return (
-    <div className="theme-toggle">
+    <div className="theme-toggle upper">
       <Tooltip title={isDark ? "Switch to light mode" : "Switch to dark mode"}>
         <Icon
           className="theme-toggle__button"

--- a/src/components/CanvasEditor/ThemeToggle/ThemeToggle.jsx
+++ b/src/components/CanvasEditor/ThemeToggle/ThemeToggle.jsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Tooltip } from "@mui/material";
+import { Sun, Moon } from "lucide-react";
+import { useThemeContext, useMenuContext } from "../../../hooks";
+import {
+  THEME_DARK,
+  THEME_LIGHT,
+  LIGHT_INK,
+  DARK_INK,
+} from "../../../utils/theme";
+import "./ThemeToggle.scss";
+
+const ThemeToggle = () => {
+  const { theme, toggleTheme } = useThemeContext();
+  const { setStyle } = useMenuContext();
+  const isDark = theme === THEME_DARK;
+
+  const handleToggle = () => {
+    const next = isDark ? THEME_LIGHT : THEME_DARK;
+    // Swap the default ink so freshly drawn shapes stay visible on the new
+    // board — but only when the user is still on the other theme's default (a
+    // custom stroke is left untouched). The PropertiesPanel effect mirrors this
+    // onto canvas.currentStyle, so the tools pick it up at draw time.
+    setStyle((s) => {
+      if (next === THEME_DARK && s.stroke === LIGHT_INK) {
+        return { ...s, stroke: DARK_INK };
+      }
+      if (next === THEME_LIGHT && s.stroke === DARK_INK) {
+        return { ...s, stroke: LIGHT_INK };
+      }
+      return s;
+    });
+    toggleTheme();
+  };
+
+  const Icon = isDark ? Sun : Moon;
+  return (
+    <div className="theme-toggle">
+      <Tooltip title={isDark ? "Switch to light mode" : "Switch to dark mode"}>
+        <Icon
+          className="theme-toggle__button"
+          size={18}
+          onClick={handleToggle}
+        />
+      </Tooltip>
+    </div>
+  );
+};
+
+export default ThemeToggle;

--- a/src/components/CanvasEditor/ThemeToggle/ThemeToggle.scss
+++ b/src/components/CanvasEditor/ThemeToggle/ThemeToggle.scss
@@ -1,29 +1,20 @@
 @import "src/css/variables.scss";
 
-.zoom-panel {
+.theme-toggle {
   position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-
-  &__inner-container {
-    display: flex;
-    background-color: var(--surface-bg);
-    border-radius: var(--default-border-radius);
-    box-shadow: 0 0 var(--default-shadow-blur) var(--default-shadow-color);
-    width: 100%;
-  }
+  left: 0;
+  display: flex;
 
   &__button {
-    margin: auto 5px 0 5px;
-    padding: 10px;
-    border: none;
+    background-color: var(--surface-bg);
     color: var(--surface-text);
-    user-select: none;
+    border-radius: var(--default-border-radius);
+    box-shadow: 0 0 var(--default-shadow-blur) var(--default-shadow-color);
+    padding: 10px;
     cursor: pointer;
 
     &:hover {
       background-color: var(--default-theme-color);
-      border-radius: var(--default-border-radius);
     }
   }
 }

--- a/src/contexts/ThemeContext.jsx
+++ b/src/contexts/ThemeContext.jsx
@@ -1,0 +1,29 @@
+import React, { createContext, useEffect, useState } from "react";
+import {
+  THEME_LIGHT,
+  THEME_DARK,
+  getInitialTheme,
+  applyTheme,
+} from "../utils/theme";
+
+export const ThemeContext = createContext({
+  theme: THEME_LIGHT,
+  toggleTheme: () => {},
+});
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState(getInitialTheme);
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  const toggleTheme = () =>
+    setTheme((t) => (t === THEME_DARK ? THEME_LIGHT : THEME_DARK));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/src/contexts/index.js
+++ b/src/contexts/index.js
@@ -1,2 +1,3 @@
 export { CanvasProvider, CanvasContext } from "./CanvasContext";
 export { MenuProvider, MenuContext } from "./MenuContext";
+export { ThemeProvider, ThemeContext } from "./ThemeContext";

--- a/src/css/variables.scss
+++ b/src/css/variables.scss
@@ -14,4 +14,30 @@
   --default-border-radius: 10px;
 
   --secondary-font-size: 14px;
+
+  // Semantic surface tokens (light defaults). Dark overrides live below.
+  // --app-bg is the board itself (the transparent fabric canvas shows the body
+  // background); the rest theme the floating chrome (toolbar, panels, footer).
+  --app-bg: #ffffff;
+  --surface-bg: #ffffff;
+  --surface-text: #1e1e1e;
+  --surface-muted: #495057;
+  --surface-input-bg: #ffffff;
+}
+
+:root[data-theme="dark"] {
+  --default-theme-color: #33333c;
+  --default-theme-hoverColor: #4a4a55;
+  --default-menu-bg-color: #2b2b33;
+
+  --button-borderColor: #4a4a55;
+  --light-border-color: #3a3a42;
+
+  --default-shadow-color: rgba(0, 0, 0, 0.6);
+
+  --app-bg: #121212;
+  --surface-bg: #232329;
+  --surface-text: #e6e6ea;
+  --surface-muted: #a0a0aa;
+  --surface-input-bg: #2b2b33;
 }

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,2 +1,3 @@
 export { useCanvasContext } from "./useCanvasContext";
 export { useMenuContext } from "./useMenuContext";
+export { useThemeContext } from "./useThemeContext";

--- a/src/hooks/useThemeContext.jsx
+++ b/src/hooks/useThemeContext.jsx
@@ -1,0 +1,7 @@
+import { useContext } from "react";
+import { ThemeContext } from "../contexts/";
+
+export const useThemeContext = () => {
+  const { theme, toggleTheme } = useContext(ThemeContext);
+  return { theme, toggleTheme };
+};

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -1,0 +1,36 @@
+// Light/dark theme handling. The chosen theme is stored on the <html> element
+// as data-theme (CSS variables in css/variables.scss react to it) and persisted
+// in localStorage so it survives reloads. MUI components follow via a matching
+// palette mode wired up in App.js.
+
+export const THEME_LIGHT = "light";
+export const THEME_DARK = "dark";
+
+const STORAGE_KEY = "wb-theme";
+
+// Default stroke ("ink") per theme so freshly drawn shapes are visible on the
+// current board — dark ink on the light board, light ink on the dark board.
+export const LIGHT_INK = "#1e1e1e";
+export const DARK_INK = "#e6e6ea";
+
+export const getInitialTheme = () => {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === THEME_LIGHT || stored === THEME_DARK) return stored;
+  } catch (e) {
+    // localStorage may be unavailable (private mode) — fall through.
+  }
+  return THEME_LIGHT;
+};
+
+// Reflect the theme onto the document and persist it.
+export const applyTheme = (theme) => {
+  if (typeof document !== "undefined") {
+    document.documentElement.setAttribute("data-theme", theme);
+  }
+  try {
+    localStorage.setItem(STORAGE_KEY, theme);
+  } catch (e) {
+    // ignore persistence failures
+  }
+};


### PR DESCRIPTION
## What changed
- **Sun/Moon toggle** in the footer (bottom-left). Choice persisted in \`localStorage\` and applied to \`<html data-theme>\` **before first paint** — no light-mode flash on load for dark users.
- **Semantic CSS-variable tokens** (\`--app-bg\`, \`--surface-bg/-text/-muted/-input-bg\` in \`css/variables.scss\`) with a \`[data-theme="dark"]\` override. Every hardcoded white/black chrome colour (toolbar, properties panel, footer, header, save/help) now reads the tokens.
- **MUI palette mode** synced to the theme so portalled components (Dialog, Menu, Tooltip, Divider) match instead of staying light.
- The **board** is the \`body\` background (\`var(--app-bg)\`, light \`#ffffff\` / dark \`#121212\`); an explicit canvas background set via the background-colour tool still overrides it.
- **Default ink swaps with the theme** (dark ink on light board, light ink on dark) so freshly drawn shapes stay visible. A custom stroke the user picked is left untouched (only the still-default ink is swapped). Wired via \`MenuContext.setStyle\` → the existing PropertiesPanel mirror → \`canvas.currentStyle\`.

## Why
Item 7 on the roadmap; the headline excalidraw feature still missing.

## Test plan (in-browser)
- Toggle light↔dark: board, toolbar, properties panel, footer, header all retheme; toggle icon swaps Sun/Moon.
- Help dialog (MUI portal) renders dark with readable text and ⌘ shortcuts.
- New shape drawn in dark mode gets light ink (\`#e6e6ea\`, visible); back in light it's \`#1e1e1e\`.
- Reload preserves the chosen theme with no flash (\`data-theme\` set at module load).
- \`npm run build\` clean; prettier clean.

## Known follow-ups (not in scope)
- **Existing content keeps its colour** — a shape drawn dark in light mode stays dark (low-contrast) after switching to dark. Only *new* shapes pick up the theme ink.
- **Stroke swatch cosmetics** — in dark mode the first stroke swatch (\`#1e1e1e\`) is low-contrast on the dark panel, and there's no swatch matching the light default ink. A theme-aware "ink" swatch would polish this.