### PR TITLE
Feature: single / double-headed arrows

### DIFF
--- a/src/Handlers/EventHandlers/arrowResizeHandler.js
+++ b/src/Handlers/EventHandlers/arrowResizeHandler.js
@@ -3,14 +3,20 @@ import { fabric } from "fabric";
 import { useCanvasContext } from "../../hooks";
 import { buildArrowGroup } from "../ToolsHandler/tools/arrow";
 
-// An arrow is a group of exactly a line + a path (the head).
-const isArrowGroup = (o) =>
-  o &&
-  o.type === "group" &&
-  o._objects &&
-  o._objects.length === 2 &&
-  o._objects.some((c) => c.type === "line") &&
-  o._objects.some((c) => c.type === "path");
+// An arrow is a group of one line + one or two heads (paths), nothing else.
+// One head = single-ended, two = double-ended; the config is read from the
+// child composition (no custom props to serialise).
+const isArrowGroup = (o) => {
+  if (!o || o.type !== "group" || !o._objects) return false;
+  const lines = o._objects.filter((c) => c.type === "line");
+  const heads = o._objects.filter((c) => c.type === "path");
+  return (
+    lines.length === 1 &&
+    heads.length >= 1 &&
+    heads.length <= 2 &&
+    o._objects.length === lines.length + heads.length
+  );
+};
 
 const isScaled = (o) =>
   (o.scaleX != null && o.scaleX !== 1) || (o.scaleY != null && o.scaleY !== 1);
@@ -26,22 +32,18 @@ function ArrowResizeHandler() {
     if (!canvas) return undefined;
     let rebuilding = false;
 
-    // Rebuild one scaled arrow group at scale 1 between its real endpoints.
-    // Returns the fresh arrow (already swapped onto the canvas).
+    // Rebuild one scaled arrow group at scale 1 between its real endpoints,
+    // preserving its head config (single vs double). Returns the fresh arrow
+    // (already swapped onto the canvas).
     const rebuildScaledArrow = (group) => {
-      const head = group._objects.find((c) => c.type === "path");
       const line = group._objects.find((c) => c.type === "line");
+      const heads = group._objects.filter((c) => c.type === "path");
       const matrix = group.calcTransformMatrix();
-      // The head sits at the arrow tip; its absolute centre is the new tip.
-      const tip = fabric.util.transformPoint(
-        new fabric.Point(head.left, head.top),
-        matrix,
-      );
-      // The tail is the line's OTHER endpoint. Derive it from the line's real
-      // endpoints — NOT the group's bounding box: the head inflates the bbox,
-      // so an opposite-corner tail sits off the line and tilts a horizontal
-      // arrow on drop. calcLinePoints() is relative to the line's centre; add
-      // the line's left/top (relative to the group centre) then map to absolute.
+      // Derive both endpoints from the line's real endpoints — NOT the group's
+      // bounding box: a head inflates the bbox, so an opposite-corner tail sits
+      // off the line and tilts a horizontal arrow on drop. calcLinePoints() is
+      // relative to the line's centre; add its left/top (relative to the group
+      // centre) then map to absolute.
       const lp = line.calcLinePoints();
       const end1 = fabric.util.transformPoint(
         new fabric.Point(line.left + lp.x1, line.top + lp.y1),
@@ -51,17 +53,35 @@ function ArrowResizeHandler() {
         new fabric.Point(line.left + lp.x2, line.top + lp.y2),
         matrix,
       );
-      const tail =
-        Math.hypot(end1.x - tip.x, end1.y - tip.y) >
-        Math.hypot(end2.x - tip.x, end2.y - tip.y)
-          ? end1
-          : end2;
 
-      const arrow = buildArrowGroup({ x: tail.x, y: tail.y }, tip, {
-        stroke: line.stroke,
-        strokeWidth: line.strokeWidth,
-        strokeDashArray: line.strokeDashArray,
-      });
+      let tail;
+      let tip;
+      if (heads.length === 2) {
+        // Double-headed: symmetric, so either endpoint can be the "end".
+        tail = end1;
+        tip = end2;
+      } else {
+        // Single-headed: the tip is the endpoint nearest the head.
+        const headAbs = fabric.util.transformPoint(
+          new fabric.Point(heads[0].left, heads[0].top),
+          matrix,
+        );
+        const d1 = Math.hypot(end1.x - headAbs.x, end1.y - headAbs.y);
+        const d2 = Math.hypot(end2.x - headAbs.x, end2.y - headAbs.y);
+        tip = d1 < d2 ? end1 : end2;
+        tail = d1 < d2 ? end2 : end1;
+      }
+
+      const arrow = buildArrowGroup(
+        { x: tail.x, y: tail.y },
+        { x: tip.x, y: tip.y },
+        {
+          stroke: line.stroke,
+          strokeWidth: line.strokeWidth,
+          strokeDashArray: line.strokeDashArray,
+          heads: heads.length === 2 ? "both" : "end",
+        },
+      );
       canvas.remove(group);
       canvas.add(arrow);
       arrow.setCoords();
@@ -75,13 +95,17 @@ function ArrowResizeHandler() {
     const onScaling = (e) => {
       const group = e && e.target;
       if (rebuilding || !isArrowGroup(group)) return;
-      const head = group._objects.find((c) => c.type === "path");
-      if (!head) return;
-      // Use |scale| so the head keeps a constant size AND mirrors together with
+      // Use |scale| so each head keeps a constant size AND mirrors together with
       // the line when the group is flipped (a corner dragged past the opposite
       // corner) — otherwise the line would mirror while the head stayed put.
-      head.scaleX = 1 / Math.abs(group.scaleX || 1);
-      head.scaleY = 1 / Math.abs(group.scaleY || 1);
+      const sx = 1 / Math.abs(group.scaleX || 1);
+      const sy = 1 / Math.abs(group.scaleY || 1);
+      group._objects
+        .filter((c) => c.type === "path")
+        .forEach((head) => {
+          head.scaleX = sx;
+          head.scaleY = sy;
+        });
     };
 
     const onModified = (e) => {

--- a/src/Handlers/ToolsHandler/toolStyle.js
+++ b/src/Handlers/ToolsHandler/toolStyle.js
@@ -10,7 +10,14 @@ export const DEFAULT_STYLE = {
   fill: "transparent",
   fontFamily: "Arial",
   fontSize: 24,
+  arrowHeads: "end", // "end" (single head) | "both" (double-headed)
 };
+
+// Arrowhead configurations offered for the arrow tool.
+export const ARROW_HEAD_OPTIONS = [
+  { id: "end", label: "Single-headed" },
+  { id: "both", label: "Double-headed" },
+];
 
 export const FONT_FAMILIES = [
   "Arial",

--- a/src/Handlers/ToolsHandler/tools/arrow.js
+++ b/src/Handlers/ToolsHandler/tools/arrow.js
@@ -48,7 +48,14 @@ export const buildArrowGroup = (start, end, style) => {
   if (style.heads === "both") {
     children.push(makeHead(start, angleBetween(end, start), style.stroke));
   }
-  const group = new fabric.Group(children, { objectCaching: false });
+  const group = new fabric.Group(children, {
+    objectCaching: false,
+    // Select an arrow by its actual line/head pixels, not its (large) bounding
+    // box — so two overlapping arrows can each be picked by clicking the one you
+    // mean instead of always grabbing the top box. Per-object, so filled/
+    // transparent shapes keep convenient click-anywhere bbox selection.
+    perPixelTargetFind: true,
+  });
   // Resize arrows from the corners only. Canvas uniformScaling makes corner
   // drags scale both axes together; a *side* handle scales one axis, which
   // shears/mirrors the rotated head. Hiding the side handles keeps every

--- a/src/Handlers/ToolsHandler/tools/arrow.js
+++ b/src/Handlers/ToolsHandler/tools/arrow.js
@@ -7,9 +7,28 @@ const ARROW_HEAD_PATH = "M 0 0 L 20 10 L 0 20 Z";
 const angleBetween = (start, end) =>
   (Math.atan2(end.y - start.y, end.x - start.x) * 180) / Math.PI;
 
-// Build a fresh arrow (line + fixed-size head) from start -> end with the given
-// style. Exported so the resize handler can rebuild an arrow at a new size
-// without scaling — and distorting — the head.
+// A fixed-size arrowhead (filled triangle) centred at `at`, pointing along
+// `angle`. Kept a plain child so the head config can be derived from the number
+// of path children (1 = single, 2 = double) — no custom props to persist.
+const makeHead = (at, angle, color) =>
+  new fabric.Path(ARROW_HEAD_PATH, {
+    stroke: "",
+    strokeWidth: 0,
+    fill: color,
+    originX: "center",
+    originY: "center",
+    left: at.x,
+    top: at.y,
+    angle,
+    hasControls: false,
+    hasBorders: false,
+    selectable: false,
+  });
+
+// Build a fresh arrow (line + fixed-size head(s)) from start -> end with the
+// given style. style.heads: "end" (default, single head at end) or "both"
+// (a second head at start). Exported so the resize handler and the properties
+// panel can rebuild an arrow without scaling — and distorting — the head(s).
 export const buildArrowGroup = (start, end, style) => {
   const line = new fabric.Line([start.x, start.y, end.x, end.y], {
     stroke: style.stroke,
@@ -22,20 +41,14 @@ export const buildArrowGroup = (start, end, style) => {
     hasBorders: false,
     selectable: false,
   });
-  const head = new fabric.Path(ARROW_HEAD_PATH, {
-    stroke: "",
-    strokeWidth: 0,
-    fill: style.stroke,
-    originX: "center",
-    originY: "center",
-    left: end.x,
-    top: end.y,
-    angle: angleBetween(start, end),
-    hasControls: false,
-    hasBorders: false,
-    selectable: false,
-  });
-  const group = new fabric.Group([line, head], { objectCaching: false });
+  const children = [
+    line,
+    makeHead(end, angleBetween(start, end), style.stroke),
+  ];
+  if (style.heads === "both") {
+    children.push(makeHead(start, angleBetween(end, start), style.stroke));
+  }
+  const group = new fabric.Group(children, { objectCaching: false });
   // Resize arrows from the corners only. Canvas uniformScaling makes corner
   // drags scale both axes together; a *side* handle scales one axis, which
   // shears/mirrors the rotated head. Hiding the side handles keeps every
@@ -52,7 +65,9 @@ export class Arrow extends Tool {
     this.pointer = null;
     this.line = null;
     this.arrowHead = null;
+    this.arrowHeadStart = null;
     this.style = null;
+    this.heads = "end";
     this.deleteOffset = 10;
   }
 
@@ -61,6 +76,7 @@ export class Arrow extends Tool {
     this.origX = this.pointer.x;
     this.origY = this.pointer.y;
     this.style = resolveToolStyle(canvas);
+    this.heads = canvas.currentArrowHeads === "both" ? "both" : "end";
 
     // Live preview: a plain line + head that follow the cursor; on mouse-up
     // they're replaced by a proper arrow group (buildArrowGroup).
@@ -77,19 +93,21 @@ export class Arrow extends Tool {
         selectable: false,
       },
     );
-    this.arrowHead = new fabric.Path(ARROW_HEAD_PATH, {
-      stroke: "",
-      strokeWidth: 0,
-      fill: this.style.stroke,
-      originX: "center",
-      originY: "center",
-      top: this.origY,
-      left: this.origX,
-      hasControls: false,
-      hasBorders: false,
-      selectable: false,
-    });
+    this.arrowHead = makeHead(
+      { x: this.origX, y: this.origY },
+      0,
+      this.style.stroke,
+    );
     canvas.add(this.line, this.arrowHead);
+    // Preview the second head too when drawing a double-headed arrow.
+    if (this.heads === "both") {
+      this.arrowHeadStart = makeHead(
+        { x: this.origX, y: this.origY },
+        0,
+        this.style.stroke,
+      );
+      canvas.add(this.arrowHeadStart);
+    }
   }
 
   draw(canvas, event) {
@@ -97,15 +115,17 @@ export class Arrow extends Tool {
       return;
     }
     this.pointer = canvas.getPointer(event.e);
+    const origin = { x: this.origX, y: this.origY };
     this.line.set({ x2: this.pointer.x, y2: this.pointer.y });
     this.line.setCoords();
     this.arrowHead.left = this.pointer.x;
     this.arrowHead.top = this.pointer.y;
-    this.arrowHead.angle = angleBetween(
-      { x: this.origX, y: this.origY },
-      this.pointer,
-    );
+    this.arrowHead.angle = angleBetween(origin, this.pointer);
     this.arrowHead.setCoords();
+    if (this.arrowHeadStart) {
+      this.arrowHeadStart.angle = angleBetween(this.pointer, origin);
+      this.arrowHeadStart.setCoords();
+    }
   }
 
   done(canvas) {
@@ -117,13 +137,14 @@ export class Arrow extends Tool {
       this.pointer.y - this.origY,
     );
     canvas.remove(this.line, this.arrowHead);
+    if (this.arrowHeadStart) canvas.remove(this.arrowHeadStart);
     if (length < this.deleteOffset) {
       return;
     }
     const arrow = buildArrowGroup(
       { x: this.origX, y: this.origY },
       { x: this.pointer.x, y: this.pointer.y },
-      this.style || resolveToolStyle(canvas),
+      { ...(this.style || resolveToolStyle(canvas)), heads: this.heads },
     );
     arrow.setCoords();
     canvas.add(arrow);

--- a/src/components/Canvas/Canvas.jsx
+++ b/src/components/Canvas/Canvas.jsx
@@ -31,6 +31,10 @@ function Canvas() {
       // renders the active object on top, so selecting a filled shape that
       // sits under text (or another shape) hides what's above it.
       preserveObjectStacking: true,
+      // A few px of slack when per-pixel target finding is on (arrows), so a
+      // thin 3px line is still easy to click. Only consulted for objects with
+      // perPixelTargetFind, so bbox selection of shapes is unaffected.
+      targetFindTolerance: 5,
       height: window.screen.height,
       width: window.screen.width,
     });

--- a/src/components/CanvasEditor/PropertiesPanel/PropertiesPanel.jsx
+++ b/src/components/CanvasEditor/PropertiesPanel/PropertiesPanel.jsx
@@ -1,6 +1,14 @@
 import React, { useEffect, useRef } from "react";
+import { fabric } from "fabric";
 import { Tooltip } from "@mui/material";
-import { BringToFront, SendToBack, ChevronUp, ChevronDown } from "lucide-react";
+import {
+  BringToFront,
+  SendToBack,
+  ChevronUp,
+  ChevronDown,
+  ArrowRight,
+  ArrowLeftRight,
+} from "lucide-react";
 import { useMenuContext, useCanvasContext } from "../../../hooks";
 import { TOOL_CONSTANTS } from "../../../constants";
 import {
@@ -10,9 +18,11 @@ import {
   STROKE_STYLES,
   FONT_FAMILIES,
   FONT_SIZES,
+  ARROW_HEAD_OPTIONS,
   toFabricStyle,
   toTextStyle,
 } from "../../../Handlers/ToolsHandler/toolStyle";
+import { buildArrowGroup } from "../../../Handlers/ToolsHandler/tools/arrow";
 import "./PropertiesPanel.scss";
 
 // Tools whose new shapes pick up the current style; the panel shows for these
@@ -31,6 +41,19 @@ const STYLEABLE_TOOLS = new Set([
 const isText = (obj) =>
   obj &&
   (obj.type === "i-text" || obj.type === "text" || obj.type === "textbox");
+
+// An arrow is a group of one line + one or two heads (paths).
+const isArrowObject = (o) => {
+  if (!o || o.type !== "group" || !o._objects) return false;
+  const lines = o._objects.filter((c) => c.type === "line");
+  const heads = o._objects.filter((c) => c.type === "path");
+  return (
+    lines.length === 1 &&
+    heads.length >= 1 &&
+    heads.length <= 2 &&
+    o._objects.length === lines.length + heads.length
+  );
+};
 
 // Best-effort reverse of strokeDashArray -> friendly style name.
 const dashToStyle = (dash, width) => {
@@ -56,6 +79,8 @@ const PropertiesPanel = () => {
     if (!canvas) return;
     canvas.currentStyle = toFabricStyle(style);
     canvas.currentTextStyle = toTextStyle(style);
+    // Arrowheads aren't a fabric prop — expose it separately for the arrow tool.
+    canvas.currentArrowHeads = style.arrowHeads;
     if (canvas.freeDrawingBrush) {
       canvas.freeDrawingBrush.color = style.stroke;
     }
@@ -141,6 +166,50 @@ const PropertiesPanel = () => {
     applyToActive(next);
   };
 
+  // Arrowheads can't be set with obj.set() — the head is a child object — so a
+  // selected arrow is rebuilt with the new config. Also updates the default for
+  // the next drawn arrow.
+  const setArrowHeads = (mode) => {
+    const next = { ...styleRef.current, arrowHeads: mode };
+    styleRef.current = next;
+    setStyle(next);
+    if (!canvas || !isArrowObject(activeObject)) return;
+
+    const group = activeObject;
+    const line = group._objects.find((c) => c.type === "line");
+    const matrix = group.calcTransformMatrix();
+    const lp = line.calcLinePoints();
+    const p1 = fabric.util.transformPoint(
+      new fabric.Point(line.left + lp.x1, line.top + lp.y1),
+      matrix,
+    );
+    const p2 = fabric.util.transformPoint(
+      new fabric.Point(line.left + lp.x2, line.top + lp.y2),
+      matrix,
+    );
+    const arrow = buildArrowGroup(
+      { x: p1.x, y: p1.y },
+      { x: p2.x, y: p2.y },
+      {
+        stroke: line.stroke,
+        strokeWidth: line.strokeWidth,
+        strokeDashArray: line.strokeDashArray,
+        heads: mode,
+      },
+    );
+
+    const supportsHistory = typeof canvas._historySaveAction === "function";
+    if (supportsHistory) canvas.historyProcessing = true;
+    canvas.remove(group);
+    canvas.add(arrow);
+    arrow.setCoords();
+    canvas.setActiveObject(arrow);
+    if (supportsHistory) canvas.historyProcessing = false;
+    canvas.requestRenderAll();
+    // One history entry (and a persistence save) for the head change.
+    canvas.fire("object:modified", { target: arrow });
+  };
+
   // Reorder the selection's z-index. sendToBack/sendBackwards process in
   // reverse so a multi-selection keeps its internal stacking order.
   const reorder = (method) => {
@@ -164,6 +233,17 @@ const PropertiesPanel = () => {
   // Text context shows font controls; shapes show fill/width/style.
   const textContext =
     isText(activeObject) || activeTool === TOOL_CONSTANTS.FONT;
+
+  // Arrow context adds the arrowheads control. When an arrow is selected, the
+  // active option reflects that arrow's own head count; otherwise the default.
+  const selectedArrowHeads = isArrowObject(activeObject)
+    ? activeObject._objects.filter((c) => c.type === "path").length === 2
+      ? "both"
+      : "end"
+    : null;
+  const arrowContext =
+    activeTool === TOOL_CONSTANTS.ARROW || selectedArrowHeads !== null;
+  const activeHeads = selectedArrowHeads || style.arrowHeads;
 
   return (
     <div className="properties-panel upper">
@@ -322,6 +402,34 @@ const PropertiesPanel = () => {
             </div>
           </div>
         </>
+      )}
+
+      {arrowContext && (
+        <div className="properties-panel__group">
+          <span className="properties-panel__label">Arrowheads</span>
+          <div className="properties-panel__row">
+            {ARROW_HEAD_OPTIONS.map((opt) => (
+              <Tooltip title={opt.label} key={opt.id}>
+                <button
+                  type="button"
+                  className={
+                    activeHeads === opt.id
+                      ? "properties-panel__btn active"
+                      : "properties-panel__btn"
+                  }
+                  onClick={() => setArrowHeads(opt.id)}
+                  aria-label={opt.label}
+                >
+                  {opt.id === "both" ? (
+                    <ArrowLeftRight size={16} />
+                  ) : (
+                    <ArrowRight size={16} />
+                  )}
+                </button>
+              </Tooltip>
+            ))}
+          </div>
+        </div>
       )}
 
       {activeObject && (

--- a/src/components/CanvasEditor/PropertiesPanel/PropertiesPanel.scss
+++ b/src/components/CanvasEditor/PropertiesPanel/PropertiesPanel.scss
@@ -95,6 +95,10 @@
     border: 1px solid var(--light-border-color);
     border-radius: 6px;
     background: var(--surface-input-bg);
+    // Themed text/icon colour — without this the S/M/L labels and the Layer
+    // and Arrowheads lucide icons (currentColor) fall back to black and vanish
+    // on the dark panel.
+    color: var(--surface-text);
     cursor: pointer;
 
     &.active {


### PR DESCRIPTION
## What changed
- **Arrowheads control** in the properties panel (arrow tool or a selected arrow): single (→) and double (⇄). Sets the default for new arrows and rebuilds a selected arrow in place.
- `buildArrowGroup` takes `style.heads`; head config is derived from the child path count (1/2) — no custom props, survives undo + reload.
- `arrowResizeHandler` generalised to 1–2 heads.
- Double-headed live preview while drawing.
- **Arrow selection (per-pixel target finding):** two overlapping arrows both filled a large bounding box, so clicking one always grabbed the top box. Arrows now set `perPixelTargetFind` so each is picked by its actual line/head pixels (with a 5px `targetFindTolerance` so a thin line stays clickable). Per-object — filled/transparent shapes keep click-anywhere bbox selection.

## Test plan (in-browser, real DOM)
- Draw single / double (incl. vertical); switch a selected arrow between them (rebuild in place, no duplication).
- Resize single & double: heads stay fixed-size, line width constant, direction preserved.
- Reload: head config persists.
- Two arrows drawn ~16px apart with overlapping boxes → clicking each line selects the intended arrow (not the top one). Transparent rectangle still selects by clicking its interior.
- `npm run build` clean; prettier clean.

## Scope note
Only single/double heads (no "none" — that's the Line tool). Depends on nothing; the dark-mode contrast of the new Arrowheads icons is fixed separately in #93.