### PR TITLE
Bug Fix: dark-mode contrast for panel buttons (Size / Layer / Arrowheads)

### DIFF
--- a/src/components/CanvasEditor/PropertiesPanel/PropertiesPanel.scss
+++ b/src/components/CanvasEditor/PropertiesPanel/PropertiesPanel.scss
@@ -95,6 +95,10 @@
     border: 1px solid var(--light-border-color);
     border-radius: 6px;
     background: var(--surface-input-bg);
+    // Themed text/icon colour — without this the S/M/L labels and the Layer
+    // and Arrowheads lucide icons (currentColor) fall back to black and vanish
+    // on the dark panel.
+    color: var(--surface-text);
     cursor: pointer;
 
     &.active {


### PR DESCRIPTION
## What changed
- Added `color: var(--surface-text)` to `.properties-panel__btn`.

## Why
Reported while testing in dark mode: the **Size** (S/M/L) labels and the **Layer** icons were invisible (dark-on-dark). The button had no themed text colour, so the labels and the lucide icons (which use `currentColor`) fell back to black. This also caused a follow-on confusion — because the size labels/active-highlight were unreadable, text got created at inconsistent sizes ("both small but differ in size"). The font/size controls themselves work correctly (verified: Size L → fontSize 36; Arial/Georgia/Courier render distinctly).

## Test plan
- Dark mode: S/M/L labels, the active-size highlight, and the Layer/Arrowheads icons are all legible.
- Light mode: `--surface-text` is `#1e1e1e` (the previous effective default) — no visual change.
- `npm run build` clean.

## Not a bug
- "Arial vs Helvetica shows no difference" is expected — Helvetica falls back to Arial on most systems. Georgia/Times/Courier differ as expected.
- Object selection works in dark mode (verified); the earlier impression was the unreadable controls above.