### PR TITLE
Feature: copy & paste (Cmd/Ctrl+C / +V), paste at cursor

### DIFF
--- a/src/Handlers/EventHandlers/keyBoardHandler.js
+++ b/src/Handlers/EventHandlers/keyBoardHandler.js
@@ -1,11 +1,13 @@
 import { useCanvasContext } from "../../hooks";
-import { useEffect, useCallback } from "react";
+import { useEffect, useCallback, useRef } from "react";
 import { fabric } from "fabric";
 import {
   isCtrlShiftZ,
   isArrow,
   isCtrlA,
+  isCtrlC,
   isCtrlD,
+  isCtrlV,
   isCtrlZ,
   isCtrlMinus,
   isCtrlPlus,
@@ -33,6 +35,11 @@ const runAsSingleHistoryStep = (canvas, mutate) => {
 
 function KeyBoardHandler() {
   const { canvas, activeObject, setZoomRatio } = useCanvasContext();
+
+  // In-app clipboard (a cloned object) and the last pointer position over the
+  // canvas, so paste can drop at the cursor like excalidraw.
+  const clipboardRef = useRef(null);
+  const lastPointerRef = useRef(null);
 
   const handleDeleteSelected = () => {
     if (!activeObject || !canvas) return;
@@ -79,6 +86,51 @@ function KeyBoardHandler() {
       });
       canvas.setActiveObject(clonedObj);
       canvas.renderAll();
+    });
+  };
+
+  // Copy the current selection into the in-app clipboard (clone so later edits
+  // to the original don't change what gets pasted).
+  const copyObjects = () => {
+    if (!activeObject || !canvas) return;
+    activeObject.clone((cloned) => {
+      clipboardRef.current = cloned;
+    });
+  };
+
+  // Paste a fresh clone of the clipboard — at the cursor for a single object,
+  // or nudged by an offset for a multi-selection (whose child coords make
+  // centring unreliable). Repeated pastes keep cloning the same clipboard.
+  const pasteObjects = () => {
+    const clip = clipboardRef.current;
+    if (!clip || !canvas) return;
+    clip.clone((clonedObj) => {
+      canvas.discardActiveObject();
+      const pointer = lastPointerRef.current;
+      runAsSingleHistoryStep(canvas, () => {
+        if (clonedObj.type === "activeSelection") {
+          clonedObj.set({ left: clonedObj.left + 20, top: clonedObj.top + 20 });
+          clonedObj.canvas = canvas;
+          clonedObj.forEachObject((obj) => canvas.add(obj));
+          clonedObj.setCoords();
+        } else {
+          if (pointer) {
+            clonedObj.set({
+              left: pointer.x - clonedObj.getScaledWidth() / 2,
+              top: pointer.y - clonedObj.getScaledHeight() / 2,
+            });
+          } else {
+            clonedObj.set({
+              left: clonedObj.left + 20,
+              top: clonedObj.top + 20,
+            });
+          }
+          clonedObj.setCoords();
+          canvas.add(clonedObj);
+        }
+      });
+      canvas.setActiveObject(clonedObj);
+      canvas.requestRenderAll();
     });
   };
 
@@ -134,6 +186,10 @@ function KeyBoardHandler() {
   }, [activeObject, canvas]);
 
   useEffect(() => {
+    // Track the pointer over the canvas (scene coords) so paste can drop there.
+    const onMove = (opt) => {
+      lastPointerRef.current = canvas.getPointer(opt.e);
+    };
     const keyManager = (e) => {
       switch (true) {
         // Delete (46, = fn+Delete on Mac) and Backspace (8, the Mac "delete"
@@ -143,6 +199,18 @@ function KeyBoardHandler() {
           if (activeObject && !activeObject.isEditing) {
             e.preventDefault();
             handleDeleteSelected(canvas);
+          }
+          break;
+        case isCtrlC(e): // copy selected objects (skip while editing text)
+          if (activeObject && !activeObject.isEditing) {
+            e.preventDefault();
+            copyObjects();
+          }
+          break;
+        case isCtrlV(e): // paste from the in-app clipboard
+          if (!(activeObject && activeObject.isEditing)) {
+            e.preventDefault();
+            pasteObjects();
           }
           break;
         case isCtrlD(e): // duplicate selected objects
@@ -181,10 +249,12 @@ function KeyBoardHandler() {
     };
     if (canvas) {
       window.addEventListener("keydown", keyManager);
+      canvas.on("mouse:move", onMove);
     }
     return () => {
       if (canvas) {
         window.removeEventListener("keydown", keyManager);
+        canvas.off("mouse:move", onMove);
       }
     };
   }, [canvas, activeObject]);

--- a/src/Handlers/EventHandlers/keyBoardHandler.js
+++ b/src/Handlers/EventHandlers/keyBoardHandler.js
@@ -99,8 +99,7 @@ function KeyBoardHandler() {
   };
 
   // Paste a fresh clone of the clipboard — at the cursor for a single object,
-  // or nudged by an offset for a multi-selection (whose child coords make
-  // centring unreliable). Repeated pastes keep cloning the same clipboard.
+  // or offset for a multi-selection. Repeated pastes keep cloning the clipboard.
   const pasteObjects = () => {
     const clip = clipboardRef.current;
     if (!clip || !canvas) return;
@@ -109,10 +108,39 @@ function KeyBoardHandler() {
       const pointer = lastPointerRef.current;
       runAsSingleHistoryStep(canvas, () => {
         if (clonedObj.type === "activeSelection") {
-          clonedObj.set({ left: clonedObj.left + 20, top: clonedObj.top + 20 });
-          clonedObj.canvas = canvas;
-          clonedObj.forEachObject((obj) => canvas.add(obj));
-          clonedObj.setCoords();
+          // A cloned activeSelection keeps its children in GROUP-LOCAL coords;
+          // adding them directly drops them near the origin. Un-group each child
+          // to absolute (position + scale + angle) via the group matrix, nudge
+          // by an offset, then re-form the selection.
+          const groupMatrix = clonedObj.calcTransformMatrix();
+          const pasted = [];
+          clonedObj.forEachObject((obj) => {
+            const m = fabric.util.multiplyTransformMatrices(
+              groupMatrix,
+              obj.calcOwnMatrix(),
+            );
+            const d = fabric.util.qrDecompose(m);
+            obj.set({
+              flipX: false,
+              flipY: false,
+              scaleX: d.scaleX,
+              scaleY: d.scaleY,
+              skewX: d.skewX,
+              skewY: d.skewY,
+              angle: d.angle,
+            });
+            obj.setPositionByOrigin(
+              new fabric.Point(d.translateX + 20, d.translateY + 20),
+              "center",
+              "center",
+            );
+            obj.setCoords();
+            canvas.add(obj);
+            pasted.push(obj);
+          });
+          canvas.setActiveObject(
+            new fabric.ActiveSelection(pasted, { canvas }),
+          );
         } else {
           if (pointer) {
             clonedObj.set({
@@ -127,9 +155,9 @@ function KeyBoardHandler() {
           }
           clonedObj.setCoords();
           canvas.add(clonedObj);
+          canvas.setActiveObject(clonedObj);
         }
       });
-      canvas.setActiveObject(clonedObj);
       canvas.requestRenderAll();
     });
   };

--- a/src/Handlers/EventHandlers/keyBoardHandler.js
+++ b/src/Handlers/EventHandlers/keyBoardHandler.js
@@ -110,9 +110,17 @@ function KeyBoardHandler() {
         if (clonedObj.type === "activeSelection") {
           // A cloned activeSelection keeps its children in GROUP-LOCAL coords;
           // adding them directly drops them near the origin. Un-group each child
-          // to absolute (position + scale + angle) via the group matrix, nudge
-          // by an offset, then re-form the selection.
+          // to absolute (position + scale + angle) via the group matrix, shifting
+          // the whole group so its centre lands at the cursor (else a +20 nudge),
+          // then re-form the selection.
           const groupMatrix = clonedObj.calcTransformMatrix();
+          // groupMatrix[4],[5] = the selection's centre in absolute coords.
+          let dx = 20;
+          let dy = 20;
+          if (pointer) {
+            dx = pointer.x - groupMatrix[4];
+            dy = pointer.y - groupMatrix[5];
+          }
           const pasted = [];
           clonedObj.forEachObject((obj) => {
             const m = fabric.util.multiplyTransformMatrices(
@@ -130,7 +138,7 @@ function KeyBoardHandler() {
               angle: d.angle,
             });
             obj.setPositionByOrigin(
-              new fabric.Point(d.translateX + 20, d.translateY + 20),
+              new fabric.Point(d.translateX + dx, d.translateY + dy),
               "center",
               "center",
             );

--- a/src/constants/KeyboarShorcuts.js
+++ b/src/constants/KeyboarShorcuts.js
@@ -7,6 +7,8 @@ const SHIFT = isMacOS() ? "⇧" : "Shift";
 
 export const SHORTCUTS = [
   { name: "Select all the objects", key: `${MOD} & A` },
+  { name: "Copy the objects", key: `${MOD} & C` },
+  { name: "Paste the objects", key: `${MOD} & V` },
   { name: "Duplicate the objects", key: `${MOD} & D` },
   { name: "Delete the objects", key: "Delete" },
   { name: "Move the objects", key: "Arrow keys" },

--- a/src/utils/Shortcuts.js
+++ b/src/utils/Shortcuts.js
@@ -12,6 +12,14 @@ export const isCtrlD = (e) => {
   return isMod(e) && !e.shiftKey && e.code === "KeyD";
 };
 
+export const isCtrlC = (e) => {
+  return isMod(e) && !e.shiftKey && e.code === "KeyC";
+};
+
+export const isCtrlV = (e) => {
+  return isMod(e) && !e.shiftKey && e.code === "KeyV";
+};
+
 export const isCtrlA = (e) => {
   return isMod(e) && !e.shiftKey && e.code === "KeyA";
 };


### PR DESCRIPTION
## What changed
- **Copy** (`⌘/Ctrl+C`) clones the current selection into an in-app clipboard.
- **Paste** (`⌘/Ctrl+V`) drops a fresh clone — **at the cursor** for a single object, or **+20 offset** for a multi-selection.
- **Multi-selection paste lands at correct absolute positions.** A cloned `activeSelection` keeps its children in group-local coords; adding them directly dropped the copies near the origin (e.g. `-141,-106` instead of `220,170`) with the group displaced. Fixed by un-grouping each child to absolute via the group matrix + `qrDecompose` (position, scale, angle), then re-forming the selection. This also resolves the follow-on "selection won't move right" report — the group was pasting mangled, so moving it looked broken.
- Skipped while a text object is being edited (native copy/paste still works there).
- One undo step per paste. Help → Keyboard shortcuts lists Copy/Paste.

## Test plan (in-browser, real DOM)
- Single object: copy, move mouse, paste → clone centred at cursor.
- Multi-selection: 2 rects at (200,150)/(400,300) → copy → paste → copies at (220,170)/(420,320), layout preserved, selected as a group.
- Repeated paste adds more; undo removes exactly one.
- Selection move verified (object-grab and empty-space drag both move correctly).
- `npm run build` clean; prettier clean.

## Notes / scope
- In-app clipboard only (not the OS clipboard). Pasting images from the system clipboard is a separate, larger feature — not included.