### PR TITLE
Improve reload/startup UX: persist view + last style, open in select mode

### DIFF
--- a/src/Handlers/EventHandlers/persistenceHandler.js
+++ b/src/Handlers/EventHandlers/persistenceHandler.js
@@ -19,6 +19,11 @@ function PersistenceHandler() {
       canvas.loadFromJSON(scene, () => {
         // Restored objects should be selectable once the cursor tool is used.
         canvas.getObjects().forEach((obj) => obj.set({ selectable: true }));
+        // Restore the pan/zoom so the board reopens exactly where it was left
+        // (canvas.toJSON omits the viewport, so we stash it on the scene).
+        if (Array.isArray(scene.viewport)) {
+          canvas.setViewportTransform(scene.viewport);
+        }
         canvas.renderAll();
         // Reset the history baseline so the restored scene is the starting
         // point — otherwise an undo would wipe it back to empty.
@@ -30,10 +35,17 @@ function PersistenceHandler() {
       });
     });
 
+    // Serialize the scene plus the current pan/zoom (toJSON drops the viewport).
+    const buildScene = () => {
+      const scene = canvas.toJSON();
+      scene.viewport = canvas.viewportTransform;
+      return scene;
+    };
+
     const scheduleSave = () => {
       if (saveTimer.current) clearTimeout(saveTimer.current);
       saveTimer.current = setTimeout(() => {
-        saveScene(canvas.toJSON());
+        saveScene(buildScene());
         // Mark clean once written, so a later flush knows nothing is pending.
         saveTimer.current = null;
       }, SAVE_DEBOUNCE_MS);
@@ -47,7 +59,7 @@ function PersistenceHandler() {
       if (!saveTimer.current) return;
       clearTimeout(saveTimer.current);
       saveTimer.current = null;
-      saveScene(canvas.toJSON());
+      saveScene(buildScene());
     };
     const onVisibility = () => {
       if (document.visibilityState === "hidden") flushSave();
@@ -59,6 +71,7 @@ function PersistenceHandler() {
       "object:removed",
       "path:created",
       "background:changed", // fired by the background-color tool
+      "mouse:wheel", // pan / ctrl-zoom — persist the viewport (debounced)
     ];
     events.forEach((ev) => canvas.on(ev, scheduleSave));
     window.addEventListener("beforeunload", flushSave);

--- a/src/contexts/MenuContext.jsx
+++ b/src/contexts/MenuContext.jsx
@@ -13,7 +13,10 @@ export const MenuContext = createContext({
 });
 
 export const MenuProvider = ({ children }) => {
-  const [activeTool, setActiveTool] = useState(TOOL_CONSTANTS.MARKER);
+  // Open (and re-open after a reload) in the selection tool, like excalidraw —
+  // so you can immediately click/rubber-band select instead of landing in the
+  // marker and drawing when you meant to select.
+  const [activeTool, setActiveTool] = useState(TOOL_CONSTANTS.CURSOR);
   const [lockStatus, setLockStatus] = useState(false);
   // Start from the last-used style and persist it so a reload keeps the user's
   // last colour / width / fill / font / arrowhead choices.

--- a/src/contexts/MenuContext.jsx
+++ b/src/contexts/MenuContext.jsx
@@ -1,6 +1,7 @@
-import React, { createContext, useState } from "react";
+import React, { createContext, useState, useEffect } from "react";
 import { TOOL_CONSTANTS } from "../constants";
 import { DEFAULT_STYLE } from "../Handlers/ToolsHandler/toolStyle";
+import { getStoredStyle, saveStyle } from "../utils/stylePrefs";
 
 export const MenuContext = createContext({
   activeTool: null,
@@ -14,7 +15,13 @@ export const MenuContext = createContext({
 export const MenuProvider = ({ children }) => {
   const [activeTool, setActiveTool] = useState(TOOL_CONSTANTS.MARKER);
   const [lockStatus, setLockStatus] = useState(false);
-  const [style, setStyle] = useState(DEFAULT_STYLE);
+  // Start from the last-used style and persist it so a reload keeps the user's
+  // last colour / width / fill / font / arrowhead choices.
+  const [style, setStyle] = useState(getStoredStyle);
+
+  useEffect(() => {
+    saveStyle(style);
+  }, [style]);
 
   const context = {
     activeTool,

--- a/src/utils/stylePrefs.js
+++ b/src/utils/stylePrefs.js
@@ -1,0 +1,28 @@
+// Persist the last-used drawing style (colour, width, fill, font, arrowheads)
+// in localStorage so a reload restores the user's last choices instead of
+// resetting to defaults. localStorage (not IndexedDB) — it's a tiny, plain
+// object, kept separate from the (larger) scene record.
+
+import { DEFAULT_STYLE } from "../Handlers/ToolsHandler/toolStyle";
+
+const KEY = "wb-style";
+
+export const getStoredStyle = () => {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return DEFAULT_STYLE;
+    const parsed = JSON.parse(raw);
+    // Merge onto defaults so a newly-added style field is never missing.
+    return { ...DEFAULT_STYLE, ...parsed };
+  } catch (e) {
+    return DEFAULT_STYLE;
+  }
+};
+
+export const saveStyle = (style) => {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(style));
+  } catch (e) {
+    // best-effort; never break drawing over a persistence failure
+  }
+};


### PR DESCRIPTION
## What changed
- **Viewport persistence** — `canvas.toJSON()` omits pan/zoom, so reload reset the view and content appeared "somewhere else." The `viewportTransform` is now saved with the scene and restored; wheel pan/ctrl-zoom also triggers the debounced save.
- **Last-used style persistence** — the drawing style (stroke, fill, width, style, font, arrowheads) is saved to `localStorage` and restored, so the panel and new shapes keep your last choices instead of resetting.
- **Open in the selection tool** — the app (and every reload) previously started on the **marker/pencil**, so a click- or rubber-band-select just drew instead. This was the "rubber-band / selection doesn't work after reload" report. It now defaults to the **pointer** (like excalidraw), so the board opens ready to select.

## Why
Reported: "reload sends the view somewhere else", "last colour should be autopopulated", and (from the screen recording) selection/rubber-band not working — which was actually the app opening in draw mode after reload.

## Test plan (in-browser)
- Pick red stroke → reload → red is active; set pan/zoom → reload → exact same view.
- Fresh load: active tool is the pointer, `canvas.selection === true`, `isDrawingMode === false`; rubber-band selects immediately with no tool switch.
- `npm run build` clean; prettier clean.

## Note
Undo-on-fill (also asked about) was verified working — it reverts correctly; undo just drops the selection (panel closes), which can look like nothing happened.