### PR TITLE
Feature: default the theme to the OS colour scheme

### DIFF
--- a/src/contexts/ThemeContext.jsx
+++ b/src/contexts/ThemeContext.jsx
@@ -3,7 +3,10 @@ import {
   THEME_LIGHT,
   THEME_DARK,
   getInitialTheme,
+  getStoredTheme,
+  getSystemTheme,
   applyTheme,
+  persistTheme,
 } from "../utils/theme";
 
 export const ThemeContext = createContext({
@@ -18,8 +21,33 @@ export const ThemeProvider = ({ children }) => {
     applyTheme(theme);
   }, [theme]);
 
+  // Follow the OS colour scheme live — but only until the user makes a manual
+  // choice (once they toggle, their stored pick wins and we stop following).
+  useEffect(() => {
+    let mq;
+    try {
+      mq = window.matchMedia("(prefers-color-scheme: dark)");
+    } catch (e) {
+      return undefined;
+    }
+    if (!mq) return undefined;
+    const onChange = () => {
+      if (!getStoredTheme()) setTheme(getSystemTheme());
+    };
+    if (mq.addEventListener) mq.addEventListener("change", onChange);
+    else if (mq.addListener) mq.addListener(onChange);
+    return () => {
+      if (mq.removeEventListener) mq.removeEventListener("change", onChange);
+      else if (mq.removeListener) mq.removeListener(onChange);
+    };
+  }, []);
+
   const toggleTheme = () =>
-    setTheme((t) => (t === THEME_DARK ? THEME_LIGHT : THEME_DARK));
+    setTheme((t) => {
+      const next = t === THEME_DARK ? THEME_LIGHT : THEME_DARK;
+      persistTheme(next);
+      return next;
+    });
 
   return (
     <ThemeContext.Provider value={{ theme, toggleTheme }}>

--- a/src/utils/stylePrefs.js
+++ b/src/utils/stylePrefs.js
@@ -4,18 +4,27 @@
 // object, kept separate from the (larger) scene record.
 
 import { DEFAULT_STYLE } from "../Handlers/ToolsHandler/toolStyle";
+import { getInitialTheme, THEME_DARK, LIGHT_INK, DARK_INK } from "./theme";
 
 const KEY = "wb-style";
+
+// Default style whose ink matches the INITIAL theme, so shapes drawn on a
+// system-dark board come out light (visible) even before any manual theme
+// toggle — the toggle's ink-swap only fires on a manual switch.
+const themedDefault = () => ({
+  ...DEFAULT_STYLE,
+  stroke: getInitialTheme() === THEME_DARK ? DARK_INK : LIGHT_INK,
+});
 
 export const getStoredStyle = () => {
   try {
     const raw = localStorage.getItem(KEY);
-    if (!raw) return DEFAULT_STYLE;
+    if (!raw) return themedDefault();
     const parsed = JSON.parse(raw);
-    // Merge onto defaults so a newly-added style field is never missing.
-    return { ...DEFAULT_STYLE, ...parsed };
+    // Merge onto the themed default; a stored choice wins.
+    return { ...themedDefault(), ...parsed };
   } catch (e) {
-    return DEFAULT_STYLE;
+    return themedDefault();
   }
 };
 

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -1,7 +1,7 @@
-// Light/dark theme handling. The chosen theme is stored on the <html> element
-// as data-theme (CSS variables in css/variables.scss react to it) and persisted
-// in localStorage so it survives reloads. MUI components follow via a matching
-// palette mode wired up in App.js.
+// Light/dark theme handling. The theme is reflected on the <html> element as
+// data-theme (CSS variables in css/variables.scss react to it; MUI palette
+// follows via App.js). On first load we follow the OS colour scheme; once the
+// user toggles, their choice is persisted in localStorage and wins over the OS.
 
 export const THEME_LIGHT = "light";
 export const THEME_DARK = "dark";
@@ -13,21 +13,44 @@ const STORAGE_KEY = "wb-theme";
 export const LIGHT_INK = "#1e1e1e";
 export const DARK_INK = "#e6e6ea";
 
-export const getInitialTheme = () => {
+// The OS colour scheme (defaults to light if it can't be read).
+export const getSystemTheme = () => {
+  try {
+    if (
+      window.matchMedia &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches
+    ) {
+      return THEME_DARK;
+    }
+  } catch (e) {
+    // matchMedia may be unavailable — fall through to light.
+  }
+  return THEME_LIGHT;
+};
+
+// The user's explicitly-chosen theme, or null if they never toggled.
+export const getStoredTheme = () => {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored === THEME_LIGHT || stored === THEME_DARK) return stored;
   } catch (e) {
     // localStorage may be unavailable (private mode) — fall through.
   }
-  return THEME_LIGHT;
+  return null;
 };
 
-// Reflect the theme onto the document and persist it.
+// A manual choice wins; otherwise follow the OS.
+export const getInitialTheme = () => getStoredTheme() || getSystemTheme();
+
+// Reflect the theme onto the document (no persistence — see persistTheme).
 export const applyTheme = (theme) => {
   if (typeof document !== "undefined") {
     document.documentElement.setAttribute("data-theme", theme);
   }
+};
+
+// Persist an explicit user choice so it overrides the OS on later loads.
+export const persistTheme = (theme) => {
   try {
     localStorage.setItem(STORAGE_KEY, theme);
   } catch (e) {


### PR DESCRIPTION
## What changed
- On first load (no manual choice), the board follows the OS **prefers-color-scheme** and keeps following it live (a `matchMedia` listener) until the user toggles; the toggle then persists and wins.
- **Default ink follows the initial theme**: when dark is captured from the system, the default stroke is now the light ink (`#e6e6ea`) so shapes are visible — previously the light→dark ink swap only fired on a *manual* toggle, so system-dark drew shapes dark-on-dark.
- `theme.js` split: `applyTheme` sets the attribute; `persistTheme` writes the explicit choice; `getInitialTheme = stored || system`.

## Why
Reported: "capture system dark mode and render that first" + follow-up "system dark works but shape colour is dark, not white."

## Test plan (in-browser, OS scheme emulated)
- OS dark + no stored → opens dark; default ink `#e6e6ea`; a drawn rectangle is a visible white outline.
- OS light + no stored → opens light; default ink `#1e1e1e`.
- Toggle to dark with OS light → reload stays dark (manual wins).
- `npm run build` compiles clean.

## Known edge (not fixed here)
- If the OS scheme changes *live* while the app is open (no manual choice), the board theme flips but the default ink doesn't re-swap. Rare; the proper long-term fix is the excalidraw-style canvas filter (plan item B3), which makes contrast a display concern and removes ink-swapping entirely.