### PR TITLE
feat: dark-mode colour adaptation for shape fills (B3)

### DIFF
--- a/src/Handlers/EventHandlers/darkColorHandler.js
+++ b/src/Handlers/EventHandlers/darkColorHandler.js
@@ -1,0 +1,53 @@
+import { useEffect, useRef } from "react";
+import { useCanvasContext, useThemeContext } from "../../hooks";
+import { dimColor } from "../../utils/themeColor";
+import { isLabeledShape, getLabelParts } from "../../utils/shapeLabel";
+
+// Shapes whose FILL is a user-chosen colour that should soften on the dark
+// board. Arrows/lines have no fill, text colour is the ink, and imported logos
+// (icon groups) keep their own brand colours — all left untouched.
+const FILLABLE = new Set(["rect", "ellipse", "triangle", "polygon"]);
+
+// Flip one object's fill between its light-mode and dark-mode tone. dimColor is
+// self-inverse, so the same call toggles either way.
+const toggleObjectFill = (obj) => {
+  if (FILLABLE.has(obj.type)) {
+    obj.set({ fill: dimColor(obj.fill) });
+    obj.dirty = true;
+  } else if (isLabeledShape(obj)) {
+    const { shape } = getLabelParts(obj);
+    if (shape) {
+      shape.set({ fill: dimColor(shape.fill) });
+      obj.dirty = true;
+    }
+  }
+};
+
+// Softens shape fills on the dark board (excalidraw-style) and restores them in
+// light mode. Fills are stored in their *displayed* state, and dimColor is
+// self-inverse, so a theme change just re-applies it to every shape — no
+// original-colour bookkeeping. New/edited shapes are dimmed at creation time in
+// toolStyle/PropertiesPanel, so they too are stored already-dimmed in dark mode.
+function DarkColorHandler() {
+  const { canvas } = useCanvasContext();
+  const { theme } = useThemeContext();
+  const firstRun = useRef(true);
+
+  useEffect(() => {
+    if (!canvas) return;
+    // Skip the initial mount: the loaded scene's fills already match the loaded
+    // theme (both persist). Only a real theme CHANGE should flip them.
+    if (firstRun.current) {
+      firstRun.current = false;
+      return;
+    }
+    canvas.getObjects().forEach(toggleObjectFill);
+    canvas.requestRenderAll();
+    // Persist the flipped scene without adding an undo entry — obj.set fires no
+    // events, so nudge the debounced save via background:changed (which
+    // persistence listens to but fabric-history does not).
+    canvas.fire("background:changed");
+  }, [theme, canvas]);
+}
+
+export default DarkColorHandler;

--- a/src/Handlers/EventHandlers/index.js
+++ b/src/Handlers/EventHandlers/index.js
@@ -3,6 +3,7 @@ export { default as MouseHandler } from "./mouseHandler";
 export { default as SelectionHandler } from "./selectionHandler";
 export { default as TextEventHandler } from "./textEventHandler";
 export { default as LabelHandler } from "./labelHandler";
+export { default as DarkColorHandler } from "./darkColorHandler";
 export { default as ZoomHandler } from "./zoomHandler";
 export { default as PersistenceHandler } from "./persistenceHandler";
 export { default as ArrowResizeHandler } from "./arrowResizeHandler";

--- a/src/Handlers/ToolsHandler/toolStyle.js
+++ b/src/Handlers/ToolsHandler/toolStyle.js
@@ -3,6 +3,8 @@
 // canvas.currentStyle; the (non-React) tool classes read it here at create
 // time so new shapes pick up the chosen stroke/fill/width/style.
 
+import { dimColor, isDarkTheme } from "../../utils/themeColor";
+
 export const DEFAULT_STYLE = {
   stroke: "#1e1e1e", // dark reads well on the white canvas
   strokeWidth: 3,
@@ -85,9 +87,16 @@ export const toFabricStyle = (style = DEFAULT_STYLE) => ({
   objectCaching: false,
 });
 
-// Fabric-ready style the tools should apply to a new object.
-export const resolveToolStyle = (canvas) =>
-  canvas?.currentStyle || toFabricStyle(DEFAULT_STYLE);
+// Fabric-ready style the tools should apply to a new object. In dark mode the
+// (light-authored) fill is dimmed so new shapes aren't harsh on the dark board;
+// stored dimmed, and DarkColorHandler flips it back on a theme toggle.
+export const resolveToolStyle = (canvas) => {
+  const style = canvas?.currentStyle || toFabricStyle(DEFAULT_STYLE);
+  if (isDarkTheme() && style.fill) {
+    return { ...style, fill: dimColor(style.fill) };
+  }
+  return style;
+};
 
 // Fabric-ready props for a new text object (colour is the stroke swatch).
 export const toTextStyle = (style = DEFAULT_STYLE) => ({

--- a/src/components/Canvas/Canvas.jsx
+++ b/src/components/Canvas/Canvas.jsx
@@ -11,6 +11,7 @@ import {
   ZoomHandler,
   PersistenceHandler,
   ArrowResizeHandler,
+  DarkColorHandler,
 } from "../../Handlers/EventHandlers";
 
 function Canvas() {
@@ -24,6 +25,7 @@ function Canvas() {
   ZoomHandler();
   PersistenceHandler();
   ArrowResizeHandler();
+  DarkColorHandler();
   const canvasRef = useRef(null);
   const { setCanvas } = useCanvasContext();
 

--- a/src/components/CanvasEditor/PropertiesPanel/PropertiesPanel.jsx
+++ b/src/components/CanvasEditor/PropertiesPanel/PropertiesPanel.jsx
@@ -28,7 +28,14 @@ import {
   getLabelParts,
   isArrow,
 } from "../../../utils/shapeLabel";
+import { dimColor, isDarkTheme } from "../../../utils/themeColor";
 import "./PropertiesPanel.scss";
+
+// In dark mode a shape's fill is stored dimmed; a chosen swatch is dimmed on
+// the way onto the object, and un-dimmed on the way back into the panel (both
+// via the self-inverse dimColor) so the panel always shows the authored colour.
+const fillForObject = (fill) =>
+  isDarkTheme() && fill && fill !== "transparent" ? dimColor(fill) : fill;
 
 // Tools whose new shapes pick up the current style; the panel shows for these
 // even with nothing selected, so a style can be chosen before drawing.
@@ -112,7 +119,7 @@ const PropertiesPanel = () => {
         ? prev.fill
         : activeObject.fill === "" || activeObject.fill == null
           ? "transparent"
-          : activeObject.fill,
+          : fillForObject(activeObject.fill), // un-dim back to authored colour
       fontFamily: text
         ? activeObject.fontFamily || prev.fontFamily
         : prev.fontFamily,
@@ -157,12 +164,14 @@ const PropertiesPanel = () => {
         // Labelled shape — style the shape child (fill/stroke/width/style); the
         // text keeps its own colour, set from the ink when it was typed.
         const { shape } = getLabelParts(obj);
-        if (shape) shape.set(fab);
+        if (shape) shape.set({ ...fab, fill: fillForObject(fab.fill) });
         obj.dirty = true;
       } else if (obj.type === "group") {
         // Icon (imported SVG logo) — leave its own colours untouched.
       } else {
-        obj.set(fab);
+        // Plain shape — dim the fill in dark mode (fillForObject) so it matches
+        // how DarkColorHandler stores fills.
+        obj.set({ ...fab, fill: fillForObject(fab.fill) });
       }
     });
     canvas.requestRenderAll();

--- a/src/utils/themeColor.js
+++ b/src/utils/themeColor.js
@@ -1,0 +1,88 @@
+import { fabric } from "fabric";
+
+// Dark-mode colour adaptation. A bright fill authored for the light board looks
+// harsh on the near-black dark board, so in dark mode we DIM it (excalidraw
+// softens colours the same way). The transform inverts HSL *lightness* while
+// keeping hue + saturation, so a bright pastel becomes a muted deep tone of the
+// same colour. It is its own inverse (L -> 1-L -> 1-(1-L) = L), so toggling the
+// theme just re-applies it — no need to stash the original colour anywhere
+// (which also keeps it reload-safe: the stored colour always matches the stored
+// theme). Full-colour imported logos are deliberately left untouched by the
+// callers of this module.
+
+const rgbToHsl = (r, g, b) => {
+  r /= 255;
+  g /= 255;
+  b /= 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  let h = 0;
+  let s = 0;
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      default:
+        h = (r - g) / d + 4;
+    }
+    h /= 6;
+  }
+  return [h, s, l];
+};
+
+const hue2rgb = (p, q, t) => {
+  if (t < 0) t += 1;
+  if (t > 1) t -= 1;
+  if (t < 1 / 6) return p + (q - p) * 6 * t;
+  if (t < 1 / 2) return q;
+  if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+  return p;
+};
+
+const hslToRgb = (h, s, l) => {
+  let r;
+  let g;
+  let b;
+  if (s === 0) {
+    r = g = b = l;
+  } else {
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    r = hue2rgb(p, q, h + 1 / 3);
+    g = hue2rgb(p, q, h);
+    b = hue2rgb(p, q, h - 1 / 3);
+  }
+  return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
+};
+
+const EMPTY = new Set(["", "transparent", "none"]);
+
+// Invert a colour's lightness (self-inverse). Passes through empty/no-fill
+// values and anything unparseable.
+export const dimColor = (color) => {
+  if (!color || EMPTY.has(color)) return color;
+  let src;
+  try {
+    src = new fabric.Color(color).getSource(); // [r, g, b, a]
+  } catch {
+    return color;
+  }
+  if (!src) return color;
+  const [h, s, l] = rgbToHsl(src[0], src[1], src[2]);
+  const [r, g, b] = hslToRgb(h, s, 1 - l);
+  const a = src[3];
+  return a == null || a === 1
+    ? `rgb(${r}, ${g}, ${b})`
+    : `rgba(${r}, ${g}, ${b}, ${a})`;
+};
+
+export const isDarkTheme = () =>
+  typeof document !== "undefined" &&
+  document.documentElement.getAttribute("data-theme") === "dark";

--- a/src/utils/themeColor.test.js
+++ b/src/utils/themeColor.test.js
@@ -1,0 +1,42 @@
+import { dimColor } from "./themeColor";
+import { fabric } from "fabric";
+
+const hslOf = (c) => {
+  const [r, g, b] = new fabric.Color(c).getSource();
+  const rr = r / 255;
+  const gg = g / 255;
+  const bb = b / 255;
+  const max = Math.max(rr, gg, bb);
+  const min = Math.min(rr, gg, bb);
+  const l = (max + min) / 2;
+  let h = 0;
+  if (max !== min) {
+    const d = max - min;
+    if (max === rr) h = (gg - bb) / d + (gg < bb ? 6 : 0);
+    else if (max === gg) h = (bb - rr) / d + 2;
+    else h = (rr - gg) / d + 4;
+    h /= 6;
+  }
+  return { h, l };
+};
+
+test("dims a bright fill to a dark tone of the same hue", () => {
+  const before = hslOf("#a5d8ff"); // bright light blue, L ~0.82
+  const after = hslOf(dimColor("#a5d8ff"));
+  expect(after.l).toBeLessThan(0.35); // now dark
+  expect(Math.abs(after.h - before.h)).toBeLessThan(0.02); // hue preserved
+});
+
+test("is its own inverse (theme toggle round-trips the colour)", () => {
+  const orig = hslOf("#a5d8ff");
+  const round = hslOf(dimColor(dimColor("#a5d8ff")));
+  expect(Math.abs(round.l - orig.l)).toBeLessThan(0.02);
+  expect(Math.abs(round.h - orig.h)).toBeLessThan(0.02);
+});
+
+test("passes through empty / no-fill values untouched", () => {
+  expect(dimColor("transparent")).toBe("transparent");
+  expect(dimColor("")).toBe("");
+  expect(dimColor(null)).toBe(null);
+  expect(dimColor("none")).toBe("none");
+});


### PR DESCRIPTION
## What
Bright fills authored for the light board looked harsh on the dark board (the light-blue box in the report). Now a shape's fill **dims to a muted deep tone of the same hue** in dark mode and **restores** in light — the way excalidraw softens colours.

## How
- `utils/themeColor.dimColor()` inverts HSL **lightness** (keeps hue + saturation) and is **self-inverse** — a theme toggle just re-applies it, so there's no original-colour bookkeeping and the stored colour always matches the stored theme (reload-safe).
- `DarkColorHandler` flips every fillable shape's fill (+ the shape child of a labelled group) on a theme change and persists it (`background:changed`, so no stray undo entry).
- New/edited fills are dimmed at source (`resolveToolStyle`, `applyToActive`) and un-dimmed back into the panel so the swatch still shows the authored colour.

## Why not excalidraw's global CSS invert filter
It would invert our **full-colour brand logos** (AWS blue → orange, etc.). So this is per-object and deliberately **skips icon groups, arrows, lines and text** — only user-chosen shape fills adapt.

## Tests / verification
+3 unit tests (dim to dark tone, self-inverse round-trip, empty passthrough) — 42 total, lint + format green. In-browser: bright fill → muted dark on toggle, logo colours intact, exact round-trip back to `#a5d8ff` on toggle to light.

## Known follow-ups (not in this PR)
- Fill **swatches** in the panel still show light values in dark mode (result is dimmed) — theming the swatch display is a small follow-up.
- Strokes/text use the existing themed-ink handling (already visible in dark); only fills are adapted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)