### PR TITLE
feat: drag-to-extend endpoint handles for the Line tool

### DIFF
--- a/src/Handlers/EventHandlers/index.js
+++ b/src/Handlers/EventHandlers/index.js
@@ -3,6 +3,7 @@ export { default as MouseHandler } from "./mouseHandler";
 export { default as SelectionHandler } from "./selectionHandler";
 export { default as TextEventHandler } from "./textEventHandler";
 export { default as LabelHandler } from "./labelHandler";
+export { default as LineEndpointHandler } from "./lineEndpointHandler";
 export { default as DarkColorHandler } from "./darkColorHandler";
 export { default as ZoomHandler } from "./zoomHandler";
 export { default as PersistenceHandler } from "./persistenceHandler";

--- a/src/Handlers/EventHandlers/lineEndpointHandler.js
+++ b/src/Handlers/EventHandlers/lineEndpointHandler.js
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { useCanvasContext } from "../../hooks";
+import { attachLineEndpointControls } from "../../utils/lineEndpoints";
+
+// Give a selected top-level line the drag-to-extend endpoint handles (like
+// arrows). Done on selection so it covers both freshly-drawn lines and lines
+// restored from a saved scene. Arrow line-children (inside a group) are skipped
+// — they have a `group`, and only the arrow's own endpoint controls apply.
+function LineEndpointHandler() {
+  const { canvas } = useCanvasContext();
+
+  useEffect(() => {
+    if (!canvas) return undefined;
+    const onSelect = () => {
+      const t = canvas.getActiveObject();
+      if (t && t.type === "line" && !t.group) attachLineEndpointControls(t);
+    };
+    canvas.on("selection:created", onSelect);
+    canvas.on("selection:updated", onSelect);
+    return () => {
+      canvas.off("selection:created", onSelect);
+      canvas.off("selection:updated", onSelect);
+    };
+  }, [canvas]);
+}
+
+export default LineEndpointHandler;

--- a/src/components/Canvas/Canvas.jsx
+++ b/src/components/Canvas/Canvas.jsx
@@ -7,6 +7,7 @@ import {
   KeyBoardHandler,
   SelectionHandler,
   LabelHandler,
+  LineEndpointHandler,
   TextEventHandler,
   ZoomHandler,
   PersistenceHandler,
@@ -21,6 +22,7 @@ function Canvas() {
   // Before TextEventHandler: its text:editing:exited must run first so the
   // shape+text regroup happens before the generic empty-text cleanup.
   LabelHandler();
+  LineEndpointHandler();
   TextEventHandler();
   ZoomHandler();
   PersistenceHandler();

--- a/src/utils/lineEndpoints.js
+++ b/src/utils/lineEndpoints.js
@@ -1,0 +1,73 @@
+import { fabric } from "fabric";
+
+// Excalidraw-style endpoint handles for the Line tool: two draggable controls
+// (p1, p2) at the line's ends, matching the arrow's (utils/arrowEndpoints). A
+// bare fabric.Line is simpler than an arrow group — setting x1/y1 or x2/y2 and
+// calling setCoords() moves that end and leaves the other put.
+
+const IDENTITY = [1, 0, 0, 1, 0, 0];
+const vptOf = (obj) => (obj.canvas ? obj.canvas.viewportTransform : IDENTITY);
+
+// Absolute (screen) position of an endpoint, for drawing the handle.
+const endpointAbs = (line, key) => {
+  const lp = line.calcLinePoints();
+  const local = key === "p1" ? { x: lp.x1, y: lp.y1 } : { x: lp.x2, y: lp.y2 };
+  return fabric.util.transformPoint(
+    new fabric.Point(local.x, local.y),
+    fabric.util.multiplyTransformMatrices(
+      vptOf(line),
+      line.calcTransformMatrix(),
+    ),
+  );
+};
+
+// Move one endpoint to a SCENE-coordinate point.
+export const setLineEndpoint = (line, key, scene) => {
+  if (key === "p1") line.set({ x1: scene.x, y1: scene.y });
+  else line.set({ x2: scene.x, y2: scene.y });
+  line.setCoords();
+};
+
+const positionHandler = (key) =>
+  function (dim, finalMatrix, line) {
+    return endpointAbs(line, key);
+  };
+
+const actionHandler = (key) =>
+  function (eventData, transform, x, y) {
+    const line = transform.target;
+    // control pointer is in screen coords -> map to scene (undo the viewport)
+    const scene = fabric.util.transformPoint(
+      new fabric.Point(x, y),
+      fabric.util.invertTransform(vptOf(line)),
+    );
+    setLineEndpoint(line, key, scene);
+    return true;
+  };
+
+const renderHandle = (ctx, left, top) => {
+  ctx.save();
+  ctx.beginPath();
+  ctx.arc(left, top, 5, 0, 2 * Math.PI, false);
+  ctx.fillStyle = "#ffffff";
+  ctx.strokeStyle = "#4f46e5";
+  ctx.lineWidth = 1.5;
+  ctx.fill();
+  ctx.stroke();
+  ctx.restore();
+};
+
+const makeControl = (key) =>
+  new fabric.Control({
+    positionHandler: positionHandler(key),
+    actionHandler: actionHandler(key),
+    actionName: "lineEndpoint",
+    cursorStyle: "pointer",
+    render: renderHandle,
+  });
+
+// Give a bare line the two endpoint handles instead of the bounding-box ones.
+export const attachLineEndpointControls = (line) => {
+  line.controls = { p1: makeControl("p1"), p2: makeControl("p2") };
+  line.hasBorders = false;
+};

--- a/src/utils/lineEndpoints.test.js
+++ b/src/utils/lineEndpoints.test.js
@@ -1,0 +1,24 @@
+import { fabric } from "fabric";
+import { setLineEndpoint, attachLineEndpointControls } from "./lineEndpoints";
+
+test("setLineEndpoint moves one end and leaves the other put", () => {
+  const line = new fabric.Line([200, 200, 500, 300], { stroke: "#111" });
+  setLineEndpoint(line, "p2", { x: 600, y: 150 });
+  expect(line.x1).toBe(200);
+  expect(line.y1).toBe(200);
+  expect(line.x2).toBe(600);
+  expect(line.y2).toBe(150);
+
+  setLineEndpoint(line, "p1", { x: 120, y: 400 });
+  expect(line.x1).toBe(120);
+  expect(line.y1).toBe(400);
+  expect(line.x2).toBe(600); // p2 untouched
+  expect(line.y2).toBe(150);
+});
+
+test("attachLineEndpointControls installs p1/p2 handles and hides the box", () => {
+  const line = new fabric.Line([0, 0, 100, 0], { stroke: "#111" });
+  attachLineEndpointControls(line);
+  expect(Object.keys(line.controls)).toEqual(["p1", "p2"]);
+  expect(line.hasBorders).toBe(false);
+});


### PR DESCRIPTION
## What changed
- The **Line** tool now gets the same drag-to-extend endpoint handles as arrows: selecting a top-level line shows two draggable dots (`p1`/`p2`) at its ends, with a **pointer** cursor and no bounding box.
- Dragging an endpoint re-aims / extends the line while the other end stays fixed (`setLineEndpoint` sets `x1/y1` or `x2/y2` + `setCoords`).
- Arrow line-children are explicitly skipped (they carry a `group`), so the arrow's own endpoint controls stay authoritative.

## Why
Parity with the arrow endpoint UX (A1.5) — user asked "line extension should be same as arrow using pointer".

## How it works
- `utils/lineEndpoints.js` — one custom `fabric.Control` per endpoint; screen↔scene mapping via `invert(viewportTransform)`; `screenMatrix`-style guard when the line isn't on a canvas yet.
- `Handlers/EventHandlers/lineEndpointHandler.js` — attaches controls on `selection:created`/`selection:updated` for a top-level line (covers freshly-drawn and reloaded lines).
- Wired into `Canvas.jsx` after `LabelHandler`.

## Test plan
- Unit: `src/utils/lineEndpoints.test.js` — `setLineEndpoint` moves one end and leaves the other put; `attachLineEndpointControls` installs `p1`/`p2` and hides the box.
- Manual (in-browser): drew a line, confirmed two endpoint dots + no bbox, dragged p2 (500,300)→(700,150) with p1 fixed at (200,300), pointer cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Stack
`master → #104 (sketchy) → #106 (labels+font) → #108 (sketchy-resize) → **this**`. Merge from the bottom up (or squash the chain in order). This PR's diff is scoped to the line-endpoint files only.
