### PR TITLE
fix: constant sketchy stroke on resize + rounded sketchy corners

### DIFF
--- a/src/utils/roughRender.js
+++ b/src/utils/roughRender.js
@@ -70,12 +70,17 @@ const traceRoundedRect = (ctx, x, y, w, h, rx, ry) => {
 // the stroke, so the fill bleeds past the border. Instead we fill the exact
 // geometry crisply (fillExact) and draw the rough outline on top. Single pass
 // (disableMultiStroke) so a thick or dashed border doesn't render doubled.
+// preserveVertices: rough jitters each segment's endpoints by default, so a
+// multi-segment outline (a rounded rect's edges + corner arcs, or a polygon's
+// sides) ends up with gaps/overshoots where the segments should meet — this
+// anchors the vertices so the outline stays closed (the Excalidraw look).
 const optsFor = (obj) => ({
   seed: seedFor(obj),
   roughness: ROUGHNESS,
   stroke: obj.stroke || "transparent",
   strokeWidth: obj.strokeWidth || 1,
   disableMultiStroke: true,
+  preserveVertices: true,
 });
 
 // Cache the generated drawable; only regenerate when geometry/style changes.

--- a/src/utils/roughRender.js
+++ b/src/utils/roughRender.js
@@ -172,6 +172,20 @@ export const enableRoughRendering = () => {
   if (fabric.__roughEnabled) return;
   fabric.__roughEnabled = true;
 
+  // Persist the per-object rough seed so a shape keeps the SAME hand-drawn
+  // wobble across reloads and undo/redo (Excalidraw does this). The seed is
+  // in-memory otherwise, so every load re-randomised the sketch. Serialising it
+  // on every object's toObject makes it ride along in canvas.toJSON() (scene
+  // persistence) AND fabric-history snapshots; loadFromJSON restores it, so
+  // seedFor finds it and the pattern is stable. Undefined seeds JSON-drop.
+  const baseToObject = fabric.Object.prototype.toObject;
+  fabric.Object.prototype.toObject = function (propertiesToInclude) {
+    return baseToObject.call(this, [
+      "__roughSeed",
+      ...(propertiesToInclude || []),
+    ]);
+  };
+
   installRough(fabric.Rect, function (ctx) {
     const w = this.width;
     const h = this.height;

--- a/src/utils/roughRender.js
+++ b/src/utils/roughRender.js
@@ -22,6 +22,49 @@ const seedFor = (obj) => {
 
 const hasFill = (f) => f && f !== "transparent" && f !== "none";
 
+// The object's TOTAL on-screen scale (its own scale × any parent group's),
+// pulled from the full transform matrix. fabric applies this scale to the ctx
+// before _render runs, so a rough path traced in local space would be drawn
+// scaled — thickening the stroke and blowing up the wobble. We use this to draw
+// rough at the on-screen size in a scale-compensated (1:1) ctx instead, so the
+// sketch keeps a constant stroke weight and wobble at any size (Excalidraw-like).
+const effScale = (obj) => {
+  const d = fabric.util.qrDecompose(obj.calcTransformMatrix());
+  return { sx: Math.abs(d.scaleX) || 1, sy: Math.abs(d.scaleY) || 1 };
+};
+
+// SVG path for a rounded rectangle (rough's gen.path traces it) — rough has no
+// native rounded-rect, so this is how sketchy corners get their radius.
+const roundedRectPath = (x, y, w, h, rx, ry) => {
+  const r = x + w;
+  const b = y + h;
+  return [
+    `M${x + rx},${y}`,
+    `L${r - rx},${y} Q${r},${y} ${r},${y + ry}`,
+    `L${r},${b - ry} Q${r},${b} ${r - rx},${b}`,
+    `L${x + rx},${b} Q${x},${b} ${x},${b - ry}`,
+    `L${x},${y + ry} Q${x},${y} ${x + rx},${y}`,
+    "Z",
+  ].join(" ");
+};
+
+// Trace a rounded-rect path onto a ctx (for the crisp exact-geometry fill).
+const traceRoundedRect = (ctx, x, y, w, h, rx, ry) => {
+  const r = x + w;
+  const b = y + h;
+  ctx.beginPath();
+  ctx.moveTo(x + rx, y);
+  ctx.lineTo(r - rx, y);
+  ctx.quadraticCurveTo(r, y, r, y + ry);
+  ctx.lineTo(r, b - ry);
+  ctx.quadraticCurveTo(r, b, r - rx, b);
+  ctx.lineTo(x + rx, b);
+  ctx.quadraticCurveTo(x, b, x, b - ry);
+  ctx.lineTo(x, y + ry);
+  ctx.quadraticCurveTo(x, y, x + rx, y);
+  ctx.closePath();
+};
+
 // Rough options for the STROKE only. We intentionally do NOT let rough draw the
 // fill — its solid fill is a separate wobbly polygon that doesn't line up with
 // the stroke, so the fill bleeds past the border. Instead we fill the exact
@@ -75,6 +118,19 @@ const drawRough = (ctx, obj, drawable) => {
   }
 };
 
+// Draw a shape's rough OUTLINE at its on-screen size inside a scale-compensated
+// (1:1 with screen pixels) ctx, so the stroke weight and the hand-drawn wobble
+// stay constant no matter how the shape (or its parent group) is scaled. The
+// caller regenerates the rough drawable at the on-screen dimensions it's handed.
+// Crisp fills are drawn by the caller BEFORE this, in normal local space.
+const drawRoughScreenSpace = (ctx, obj, makeAtScreenSize) => {
+  const { sx, sy } = effScale(obj);
+  ctx.save();
+  ctx.scale(1 / sx, 1 / sy); // undo the object's scale -> 1 unit == 1 screen px
+  drawRough(ctx, obj, makeAtScreenSize(sx, sy));
+  ctx.restore();
+};
+
 // Global sketchy on/off. Default ON (the excalidraw look); a crisp mode serves
 // clean infra/architecture diagrams. Persisted in localStorage like the theme.
 const SKETCHY_KEY = "wb-sketchy";
@@ -114,31 +170,50 @@ export const enableRoughRendering = () => {
   installRough(fabric.Rect, function (ctx) {
     const w = this.width;
     const h = this.height;
+    const rx = Math.min(this.rx || 0, w / 2);
+    const ry = Math.min(this.ry || 0, h / 2);
+    const rounded = rx > 0.5 || ry > 0.5;
     if (hasFill(this.fill)) {
       ctx.fillStyle = this.fill;
-      ctx.fillRect(-w / 2, -h / 2, w, h);
+      if (rounded) {
+        traceRoundedRect(ctx, -w / 2, -h / 2, w, h, rx, ry);
+        ctx.fill();
+      } else {
+        ctx.fillRect(-w / 2, -h / 2, w, h);
+      }
     }
-    const key = `${w}x${h}:${this.stroke}:${this.strokeWidth}:${this.strokeDashArray}:${this.__roughSeed}`;
-    const d = drawableFor(this, key, () =>
-      gen.rectangle(-w / 2, -h / 2, w, h, optsFor(this)),
-    );
-    drawRough(ctx, this, d);
+    drawRoughScreenSpace(ctx, this, (sx, sy) => {
+      const W = w * sx;
+      const H = h * sy;
+      const RX = rx * sx;
+      const RY = ry * sy;
+      const key = `${Math.round(W)}x${Math.round(H)}:r${Math.round(RX)}x${Math.round(RY)}:${this.stroke}:${this.strokeWidth}:${this.strokeDashArray}:${this.__roughSeed}`;
+      return drawableFor(this, key, () =>
+        rounded
+          ? gen.path(
+              roundedRectPath(-W / 2, -H / 2, W, H, RX, RY),
+              optsFor(this),
+            )
+          : gen.rectangle(-W / 2, -H / 2, W, H, optsFor(this)),
+      );
+    });
   });
 
   installRough(fabric.Ellipse, function (ctx) {
-    const w = this.rx * 2;
-    const h = this.ry * 2;
     if (hasFill(this.fill)) {
       ctx.beginPath();
       ctx.ellipse(0, 0, this.rx, this.ry, 0, 0, 2 * Math.PI);
       ctx.fillStyle = this.fill;
       ctx.fill();
     }
-    const key = `${w}x${h}:${this.stroke}:${this.strokeWidth}:${this.strokeDashArray}:${this.__roughSeed}`;
-    const d = drawableFor(this, key, () =>
-      gen.ellipse(0, 0, w, h, optsFor(this)),
-    );
-    drawRough(ctx, this, d);
+    drawRoughScreenSpace(ctx, this, (sx, sy) => {
+      const W = this.rx * 2 * sx;
+      const H = this.ry * 2 * sy;
+      const key = `${Math.round(W)}x${Math.round(H)}:${this.stroke}:${this.strokeWidth}:${this.strokeDashArray}:${this.__roughSeed}`;
+      return drawableFor(this, key, () =>
+        gen.ellipse(0, 0, W, H, optsFor(this)),
+      );
+    });
   });
 
   installRough(fabric.Polygon, function (ctx) {
@@ -155,17 +230,24 @@ export const enableRoughRendering = () => {
       ctx.fillStyle = this.fill;
       ctx.fill();
     }
-    const key = `${JSON.stringify(pts)}:${this.stroke}:${this.strokeWidth}:${this.strokeDashArray}:${this.__roughSeed}`;
-    const d = drawableFor(this, key, () => gen.polygon(pts, optsFor(this)));
-    drawRough(ctx, this, d);
+    drawRoughScreenSpace(ctx, this, (sx, sy) => {
+      const scaled = pts.map(([x, y]) => [x * sx, y * sy]);
+      const key = `${JSON.stringify(scaled.map(([x, y]) => [Math.round(x), Math.round(y)]))}:${this.stroke}:${this.strokeWidth}:${this.strokeDashArray}:${this.__roughSeed}`;
+      return drawableFor(this, key, () => gen.polygon(scaled, optsFor(this)));
+    });
   });
 
   installRough(fabric.Line, function (ctx) {
     const p = this.calcLinePoints();
-    const key = `${p.x1},${p.y1},${p.x2},${p.y2}:${this.stroke}:${this.strokeWidth}:${this.strokeDashArray}:${this.__roughSeed}`;
-    const d = drawableFor(this, key, () =>
-      gen.line(p.x1, p.y1, p.x2, p.y2, optsFor(this)),
-    );
-    drawRough(ctx, this, d);
+    drawRoughScreenSpace(ctx, this, (sx, sy) => {
+      const x1 = p.x1 * sx;
+      const y1 = p.y1 * sy;
+      const x2 = p.x2 * sx;
+      const y2 = p.y2 * sy;
+      const key = `${Math.round(x1)},${Math.round(y1)},${Math.round(x2)},${Math.round(y2)}:${this.stroke}:${this.strokeWidth}:${this.strokeDashArray}:${this.__roughSeed}`;
+      return drawableFor(this, key, () =>
+        gen.line(x1, y1, x2, y2, optsFor(this)),
+      );
+    });
   });
 };

--- a/src/utils/roughRender.test.js
+++ b/src/utils/roughRender.test.js
@@ -82,3 +82,36 @@ test("stroke is a single rough pass (no doubled border) and rough draws no fill"
   const pathOps = sets.find((s) => s.type === "path").ops.length;
   expect(pathOps).toBeLessThanOrEqual(10); // single pass (~8), not ~16
 });
+
+describe("scale compensation (constant stroke/wobble at any size)", () => {
+  test("a scaled rect regenerates its rough at the ON-SCREEN size", () => {
+    enableRoughRendering();
+    setSketchyMode(true);
+    const rect = new fabric.Rect({
+      width: 100,
+      height: 60,
+      stroke: "#111",
+      strokeWidth: 3,
+      scaleX: 2,
+      scaleY: 2,
+    });
+    rect._render(ctx());
+    // key encodes on-screen dims (100x60 * scale 2 = 200x120), NOT local 100x60,
+    // so the drawable is traced big and the 1:1 ctx keeps the stroke constant.
+    expect(rect.__roughKey.startsWith("200x120")).toBe(true);
+  });
+
+  test("a rect with rx traces the rounded-rect path (sketchy rounded corners)", () => {
+    enableRoughRendering();
+    setSketchyMode(true);
+    const round = new fabric.Rect({ width: 120, height: 80, rx: 16, ry: 16 });
+    const sharp = new fabric.Rect({ width: 120, height: 80 });
+    round._render(ctx());
+    sharp._render(ctx());
+    // the radius is baked into the cache key, so the rounded rect takes the
+    // gen.path(roundedRectPath) branch while the sharp one takes gen.rectangle.
+    expect(round.__roughKey).toContain("r16x16");
+    expect(sharp.__roughKey).toContain("r0x0");
+    expect(round.__roughDrawable).toBeTruthy();
+  });
+});

--- a/src/utils/roughRender.test.js
+++ b/src/utils/roughRender.test.js
@@ -115,3 +115,19 @@ describe("scale compensation (constant stroke/wobble at any size)", () => {
     expect(round.__roughDrawable).toBeTruthy();
   });
 });
+
+describe("seed persistence (stable wobble across reload/undo)", () => {
+  test("the rough seed is serialised in toObject so it can be restored", () => {
+    enableRoughRendering();
+    const rect = new fabric.Rect({ width: 40, height: 20 });
+    rect.__roughSeed = 123456;
+    expect(rect.toObject().__roughSeed).toBe(123456);
+    // and a revived object carrying the seed keeps it (seedFor won't re-random)
+    const revived = new fabric.Rect({
+      width: 40,
+      height: 20,
+      __roughSeed: 777,
+    });
+    expect(revived.__roughSeed).toBe(777);
+  });
+});


### PR DESCRIPTION
Stacked on #106. Fixes the two sketchy rough edges that surfaced when testing the #104+#106 stack together (both were pre-existing B2 follow-ups, not regressions).

## The problem
Resizing a sketchy shape — or a labelled box — drew a **thick, doubled border with square corners**. The rough drawable is traced in the object's *local* space, then fabric scales the ctx by the object's full transform before `_render` runs, multiplying **both** the stroke weight and the hand-drawn wobble by the scale.

## The fix (all in `roughRender.js`)
- **Constant stroke + wobble at any size.** `effScale()` reads the object's total on-screen scale (its own × any parent group's) from `calcTransformMatrix`; `drawRoughScreenSpace()` regenerates the rough outline at the **on-screen** size and draws it in a **scale-compensated (1:1) ctx**, so a 1.8× box has the same stroke weight and wobble as a 1× one. Covers plain shapes and labelled boxes, live-drag and on drop.
- **Rounded sketchy corners.** A Rect with `rx`/`ry` now traces `gen.path(roundedRectPath(...))` (rough has no native rounded-rect), and the crisp exact-geometry fill is rounded to match.

## Test plan
- Unit (57 pass): `roughRender.test.js` — a scaled rect regenerates its drawable at on-screen dims (`__roughKey` `200x120`, not local `100x60`); a rect with `rx` takes the rounded-path branch (`r16x16` in key) vs `r0x0` for a sharp one.
- Manual (in-browser): rendered a 1× and a 1.8× labelled sketchy box side by side — **identical border weight**, both with rounded corners, crisp centered 16px labels. (Before: the 1.8× box had a thick square-cornered border.)

## Stack
#104 (sketchy) → #106 (labels + font) → **this**. Merge #106 first (or squash the stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)