### PR TITLE
refactor: arrow geometry as data (fix head rotation + binding drift)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md — whiteboard
+
+Guidance for AI coding agents working in this repo.
+
+## Code style
+
+**Write self-explanatory code, not comments.** The JavaScript is the deliverable
+— names and structure should carry the meaning. Reach for a comment only when the
+code genuinely can't explain itself.
+
+- Prefer a clear name or a small extracted function over a comment.
+- When a comment is necessary, keep it to **one short line**. Explain the
+  non-obvious **why** (a gotcha, an invariant, a reason for an odd choice), never
+  the **what** the code already states.
+- No block/banner comments, no restating the line below, no commented-out code.
+- Delete a comment the moment the code makes it redundant.
+
+Good:
+
+```js
+// Re-fit re-bases the local frame; pin endpoints in scene space across it.
+```
+
+Avoid:
+
+```js
+// This function sets the value of x to the value of y plus one.
+x = y + 1;
+```
+
+## Working in this repo
+
+- Default branch: `master`. Branch off it; never commit there directly.
+- Tests: `npm run test:unit` (Jest via react-scripts). New/changed logic needs tests.
+- Lint + format: `npm run test:all` (ESLint + Prettier) must pass. Run `npm run fix` to auto-fix.
+- **Never** use `git commit --no-verify` — fix the failure instead.
+- Icons: prefer `lucide-react`.
+- Verify UI/canvas changes in the browser, not just via unit tests.

--- a/src/utils/arrowEndpoints.js
+++ b/src/utils/arrowEndpoints.js
@@ -230,29 +230,67 @@ const screenMatrix = (group) =>
     group.calcTransformMatrix(),
   );
 
-// Endpoint positions in group-local coordinates (relative to the group centre).
-// For an end that carries a head, the logical endpoint is the head's TIP vertex
-// (the visible point), NOT the connector's terminal — the connector is drawn
-// short of the tip so it doesn't poke through. heads[0] = tip end (e2),
-// heads[1] = tail end (e1) on a double-headed arrow.
-const localEndpoints = (group) => {
+// The persisted field holding an arrow's two logical endpoints in GROUP-LOCAL
+// coords: [tail, tip]. This is the SINGLE SOURCE OF TRUTH for where the arrow
+// starts and ends. The rendered children (connector, head(s), label) are
+// DERIVED from it on every layout and are NEVER read back into it.
+//
+// Why this matters: the old model answered "where does the arrow point?" by
+// reading the head's own left/top/angle (headTipOf below). That coupled the
+// logical geometry to the rendered head — so a stale head angle produced a wrong
+// endpoint, which produced a wronger head next re-route: a feedback loop that
+// showed up as "the head stops rotating" and "the binding drifts". Storing the
+// endpoints as plain data breaks the loop — a mis-rendered head can't corrupt
+// the truth; the next layout just re-derives it correctly.
+export const ARROW_GEOM_FIELD = "arrowPoints";
+
+// Reconstruct the endpoints from the rendered children. Used ONCE to migrate an
+// arrow drawn/saved before ARROW_GEOM_FIELD existed (old boards, undo snapshots),
+// after which getLocalGeom caches the result on the group.
+const reconstructEndpointsFromChildren = (group) => {
   const { line, heads } = getArrowParts(group);
   let e1;
   let e2;
   if (line.type === "polyline") {
-    // Elbow: points already live in group-local coords (see layoutElbowPolyline).
     const pts = line.points;
     e1 = { x: pts[0].x, y: pts[0].y };
     e2 = { x: pts[pts.length - 1].x, y: pts[pts.length - 1].y };
   } else {
     const lp = line.calcLinePoints();
-    e1 = { x: line.left + lp.x1, y: line.top + lp.y1 }; // tail (line start)
-    e2 = { x: line.left + lp.x2, y: line.top + lp.y2 }; // tip (line end)
+    e1 = { x: line.left + lp.x1, y: line.top + lp.y1 };
+    e2 = { x: line.left + lp.x2, y: line.top + lp.y2 };
   }
   if (heads[0]) e2 = headTipOf(heads[0]);
   if (heads[1]) e1 = headTipOf(heads[1]);
   return { e1, e2 };
 };
+
+// Write the logical endpoints (group-local) as the arrow's stored geometry.
+export const setLocalGeom = (group, e1, e2) => {
+  group[ARROW_GEOM_FIELD] = [
+    { x: e1.x, y: e1.y },
+    { x: e2.x, y: e2.y },
+  ];
+};
+
+// Read the logical endpoints (group-local). Falls back to reconstructing them
+// from the children the first time (migration), then caches.
+const getLocalGeom = (group) => {
+  const pts = group[ARROW_GEOM_FIELD];
+  if (Array.isArray(pts) && pts.length === 2) {
+    return {
+      e1: { x: pts[0].x, y: pts[0].y },
+      e2: { x: pts[1].x, y: pts[1].y },
+    };
+  }
+  const ends = reconstructEndpointsFromChildren(group);
+  setLocalGeom(group, ends.e1, ends.e2);
+  return ends;
+};
+
+// Endpoint positions in group-local coordinates (relative to the group centre) —
+// read from the stored geometry, not the rendered head.
+const localEndpoints = (group) => getLocalGeom(group);
 
 // Arrow endpoints in absolute (scene) coords — handles line or elbow polyline.
 export const sceneEndpoints = (group) => {
@@ -270,6 +308,10 @@ export const sceneEndpoints = (group) => {
 const applyEndpointsLocal = (group, start, end, presetRoute) => {
   const { line, heads, text } = getArrowParts(group);
   const elbow = line.type === "polyline";
+
+  // Record the logical endpoints as the arrow's truth BEFORE deriving anything,
+  // so the connector/head(s) below are a pure projection of it (never the source).
+  setLocalGeom(group, start, end);
 
   // The route the head/label follow. A caller (binding's obstacle-aware router)
   // may hand in a ready LOCAL route; otherwise a bound elbow uses its ports' exit
@@ -377,11 +419,34 @@ export const setArrowEndpoints = (
 // group transform, then recompute the bounds and re-base the children. Skipping
 // the restore/reset (as a naive _calcBounds does) shifts everything.
 export const refitArrowBounds = (group) => {
+  // Re-fitting moves the group's origin, which re-bases the LOCAL coordinate
+  // frame. Fabric re-bases the children automatically; the stored endpoints are
+  // plain data and won't move themselves — so pin them in SCENE space across the
+  // refit, then convert back into the new local frame. Without this the geometry
+  // would silently shift by the bbox delta after every drop.
+  const before = getLocalGeom(group);
+  const mBefore = group.calcTransformMatrix();
+  const sceneE1 = fabric.util.transformPoint(
+    new fabric.Point(before.e1.x, before.e1.y),
+    mBefore,
+  );
+  const sceneE2 = fabric.util.transformPoint(
+    new fabric.Point(before.e2.x, before.e2.y),
+    mBefore,
+  );
+
   group._restoreObjectsState();
   fabric.util.resetObjectTransform(group);
   group._calcBounds();
   group._updateObjectsCoords();
   group.setCoords();
+
+  const inv = fabric.util.invertTransform(group.calcTransformMatrix());
+  setLocalGeom(
+    group,
+    fabric.util.transformPoint(sceneE1, inv),
+    fabric.util.transformPoint(sceneE2, inv),
+  );
   group.dirty = true;
 };
 

--- a/src/utils/arrowEndpoints.js
+++ b/src/utils/arrowEndpoints.js
@@ -230,23 +230,11 @@ const screenMatrix = (group) =>
     group.calcTransformMatrix(),
   );
 
-// The persisted field holding an arrow's two logical endpoints in GROUP-LOCAL
-// coords: [tail, tip]. This is the SINGLE SOURCE OF TRUTH for where the arrow
-// starts and ends. The rendered children (connector, head(s), label) are
-// DERIVED from it on every layout and are NEVER read back into it.
-//
-// Why this matters: the old model answered "where does the arrow point?" by
-// reading the head's own left/top/angle (headTipOf below). That coupled the
-// logical geometry to the rendered head — so a stale head angle produced a wrong
-// endpoint, which produced a wronger head next re-route: a feedback loop that
-// showed up as "the head stops rotating" and "the binding drifts". Storing the
-// endpoints as plain data breaks the loop — a mis-rendered head can't corrupt
-// the truth; the next layout just re-derives it correctly.
+// Arrow's logical endpoints [tail, tip], group-local — the source of truth.
+// Children are derived from it, never read back (read-back caused head drift).
 export const ARROW_GEOM_FIELD = "arrowPoints";
 
-// Reconstruct the endpoints from the rendered children. Used ONCE to migrate an
-// arrow drawn/saved before ARROW_GEOM_FIELD existed (old boards, undo snapshots),
-// after which getLocalGeom caches the result on the group.
+// Migrate a pre-arrowPoints arrow (old board / undo snapshot) once.
 const reconstructEndpointsFromChildren = (group) => {
   const { line, heads } = getArrowParts(group);
   let e1;
@@ -265,7 +253,6 @@ const reconstructEndpointsFromChildren = (group) => {
   return { e1, e2 };
 };
 
-// Write the logical endpoints (group-local) as the arrow's stored geometry.
 export const setLocalGeom = (group, e1, e2) => {
   group[ARROW_GEOM_FIELD] = [
     { x: e1.x, y: e1.y },
@@ -273,8 +260,7 @@ export const setLocalGeom = (group, e1, e2) => {
   ];
 };
 
-// Read the logical endpoints (group-local). Falls back to reconstructing them
-// from the children the first time (migration), then caches.
+// Reconstructs + caches on first read of a pre-arrowPoints arrow.
 const getLocalGeom = (group) => {
   const pts = group[ARROW_GEOM_FIELD];
   if (Array.isArray(pts) && pts.length === 2) {
@@ -288,8 +274,6 @@ const getLocalGeom = (group) => {
   return ends;
 };
 
-// Endpoint positions in group-local coordinates (relative to the group centre) —
-// read from the stored geometry, not the rendered head.
 const localEndpoints = (group) => getLocalGeom(group);
 
 // Arrow endpoints in absolute (scene) coords — handles line or elbow polyline.
@@ -309,8 +293,7 @@ const applyEndpointsLocal = (group, start, end, presetRoute) => {
   const { line, heads, text } = getArrowParts(group);
   const elbow = line.type === "polyline";
 
-  // Record the logical endpoints as the arrow's truth BEFORE deriving anything,
-  // so the connector/head(s) below are a pure projection of it (never the source).
+  // Record the truth before deriving children from it.
   setLocalGeom(group, start, end);
 
   // The route the head/label follow. A caller (binding's obstacle-aware router)
@@ -419,11 +402,8 @@ export const setArrowEndpoints = (
 // group transform, then recompute the bounds and re-base the children. Skipping
 // the restore/reset (as a naive _calcBounds does) shifts everything.
 export const refitArrowBounds = (group) => {
-  // Re-fitting moves the group's origin, which re-bases the LOCAL coordinate
-  // frame. Fabric re-bases the children automatically; the stored endpoints are
-  // plain data and won't move themselves — so pin them in SCENE space across the
-  // refit, then convert back into the new local frame. Without this the geometry
-  // would silently shift by the bbox delta after every drop.
+  // Re-fit re-bases the local frame; pin the endpoints in scene space across it
+  // (fabric re-bases children, but this stored data won't move itself).
   const before = getLocalGeom(group);
   const mBefore = group.calcTransformMatrix();
   const sceneE1 = fabric.util.transformPoint(

--- a/src/utils/arrowEndpoints.test.js
+++ b/src/utils/arrowEndpoints.test.js
@@ -3,11 +3,14 @@ import {
   reshapeArrow,
   refitArrowBounds,
   setArrowEndpoints,
+  sceneEndpoints,
   elbowRoute,
   headCenterFor,
   headTipOf,
+  ARROW_GEOM_FIELD,
 } from "./arrowEndpoints";
 import { getArrowParts, isArrow, isElbowArrow } from "./shapeLabel";
+import { enableBindingPersistence } from "./binding";
 import { buildArrowGroup } from "../Handlers/ToolsHandler/tools/arrow";
 
 describe("elbowRoute (orthogonal routing)", () => {
@@ -246,6 +249,70 @@ describe("refitArrowBounds", () => {
     expect(Math.round(tailAfter.x)).toBe(Math.round(tailBefore.x));
     expect(Math.round(tailAfter.y)).toBe(Math.round(tailBefore.y));
     expect(a.scaleX).toBe(1);
+  });
+});
+
+describe("logical endpoints are stored DATA, decoupled from the rendered head", () => {
+  const absEnds = (a) => {
+    const { tail, tip } = sceneEndpoints(a);
+    return { tail, tip };
+  };
+
+  test("setArrowEndpoints stores the two logical endpoints on the group", () => {
+    const c = new fabric.Canvas(document.createElement("canvas"));
+    const a = arrow();
+    c.add(a);
+    setArrowEndpoints(a, { x: 40, y: 40 }, { x: 240, y: 180 });
+    const geom = a[ARROW_GEOM_FIELD];
+    expect(Array.isArray(geom)).toBe(true);
+    expect(geom).toHaveLength(2);
+  });
+
+  test("corrupting the head does NOT move the logical endpoint (loop is broken)", () => {
+    const c = new fabric.Canvas(document.createElement("canvas"));
+    const a = arrow();
+    c.add(a);
+    setArrowEndpoints(a, { x: 40, y: 40 }, { x: 240, y: 180 });
+    const before = absEnds(a);
+
+    // Simulate a stale/garbled head — the old model read the endpoint back out
+    // of this, so it would have drifted. The data model must ignore it.
+    const { heads } = getArrowParts(a);
+    heads[0].set({ angle: 137, left: -999, top: 999 });
+    heads[0].setCoords();
+
+    const after = absEnds(a);
+    expect(Math.round(after.tip.x)).toBe(Math.round(before.tip.x));
+    expect(Math.round(after.tip.y)).toBe(Math.round(before.tip.y));
+    expect(Math.round(after.tail.x)).toBe(Math.round(before.tail.x));
+    expect(Math.round(after.tail.y)).toBe(Math.round(before.tail.y));
+  });
+
+  test("the stored geometry persists via toObject", () => {
+    enableBindingPersistence();
+    const c = new fabric.Canvas(document.createElement("canvas"));
+    const a = arrow();
+    c.add(a);
+    setArrowEndpoints(a, { x: 10, y: 20 }, { x: 210, y: 160 });
+    const obj = a.toObject();
+    expect(Array.isArray(obj[ARROW_GEOM_FIELD])).toBe(true);
+    expect(obj[ARROW_GEOM_FIELD]).toHaveLength(2);
+  });
+
+  test("an arrow with no stored geometry migrates from its children", () => {
+    const c = new fabric.Canvas(document.createElement("canvas"));
+    const a = arrow();
+    c.add(a);
+    setArrowEndpoints(a, { x: 40, y: 40 }, { x: 240, y: 180 });
+    const before = absEnds(a);
+
+    // Old board / undo snapshot: no arrowPoints field yet.
+    delete a[ARROW_GEOM_FIELD];
+    const after = absEnds(a); // first read reconstructs + caches
+
+    expect(Math.round(after.tip.x)).toBe(Math.round(before.tip.x));
+    expect(Math.round(after.tip.y)).toBe(Math.round(before.tip.y));
+    expect(Array.isArray(a[ARROW_GEOM_FIELD])).toBe(true); // now cached
   });
 });
 

--- a/src/utils/binding.js
+++ b/src/utils/binding.js
@@ -1,6 +1,10 @@
 import { fabric } from "fabric";
 import { isArrow, isElbowArrow } from "./shapeLabel";
-import { setArrowEndpoints, sceneEndpoints } from "./arrowEndpoints";
+import {
+  setArrowEndpoints,
+  sceneEndpoints,
+  ARROW_GEOM_FIELD,
+} from "./arrowEndpoints";
 import { routeWithObstacles } from "./orthRoute";
 
 // How close two facing ports must be (on the perpendicular axis) to snap into a
@@ -388,6 +392,7 @@ export const enableBindingPersistence = () => {
       "endBinding",
       "startAnchor",
       "endAnchor",
+      ARROW_GEOM_FIELD, // logical endpoints — the arrow's stored geometry
       ...(propertiesToInclude || []),
     ]);
   };


### PR DESCRIPTION
## What changed
Arrows now store their two logical endpoints as **data** (`arrowPoints`, group-local); the rendered children (connector, head(s), label) are **derived** from that on every layout — the Excalidraw data-model idea, on the same fabric group.

- `arrowEndpoints.js` — `ARROW_GEOM_FIELD` is the source of truth; `applyEndpointsLocal` writes it before deriving; `refitArrowBounds` re-bases it across the frame change; `localEndpoints` reads it (one-time reconstruct-from-children migration for old boards/undo).
- `binding.js` — persist `arrowPoints` so geometry survives reload/undo.
- tests — lock the invariant.

## Why
"Where does the arrow point?" used to be answered by reading the head's own `left/top/angle` back out. That coupled truth to render: a stale head → wrong endpoint → wronger head next re-route. That feedback loop was **"the arrowhead stops rotating"** and **"bindings get messed up"**. Storing endpoints as data breaks the loop.

## Test plan
- 97 unit tests pass; lint + prettier clean.
- New invariant tests: a corrupted head no longer moves the endpoint; geometry persists via `toObject`; old arrows migrate.
- Verified live (real code via a temp bridge, since removed): straight + elbow heads rotate correctly (straight: 4 distinct angles; elbow: 0/90/−90/180 by facing side); endpoints stay glued to borders; **0px drift over 25 re-routes and across refit** (no reselect jump).

Stacks on #113 (elbow routing) — base is `fix/elbow-smart-and-filters`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)