### PR TITLE
fix: dashes + stroke apply to elbow arrows in the style panel

### DIFF
--- a/src/components/CanvasEditor/PropertiesPanel/PropertiesPanel.jsx
+++ b/src/components/CanvasEditor/PropertiesPanel/PropertiesPanel.jsx
@@ -163,7 +163,9 @@ const PropertiesPanel = () => {
         // each: line-like children take the stroke/width/dash; the filled
         // head(s) take the stroke colour as their fill.
         obj._objects.forEach((child) => {
-          if (child.type === "line") {
+          // "line" = straight connector, "polyline" = elbow connector — both
+          // take the stroke/width/dash (an elbow arrow was being skipped).
+          if (child.type === "line" || child.type === "polyline") {
             child.set({
               stroke: fab.stroke,
               strokeWidth: fab.strokeWidth,


### PR DESCRIPTION
## What changed
`applyToActive` in the properties panel only styled the `line` connector, so an **elbow** arrow (whose connector is a `polyline`) was skipped — changing dash, width, or colour on a selected elbow arrow did nothing to the line (only the head recoloured). Now it includes `polyline`.

One line + comment. Off `master`, targets `master` — independent of the open elbow PRs (#113/#114).

## Test plan
- Verified in-browser: select an elbow arrow → apply **dashed** and **thick** → the polyline now gets `strokeDashArray` + `strokeWidth` and renders as a thick dashed elbow (before: no change). Straight arrows and shapes unaffected.
- 85 unit tests pass; lint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)