### PR TITLE
feat: auto-layout (Arrange) — tidy a bound diagram into a clean flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "whiteboard",
       "version": "0.1.0",
       "dependencies": {
+        "@dagrejs/dagre": "^3.1.1",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.14.6",
@@ -2373,6 +2374,21 @@
       "peerDependencies": {
         "postcss-selector-parser": "^6.0.10"
       }
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.1.1.tgz",
+      "integrity": "sha512-zroZB1dFOFiGgv4Xcrn1DckB1o4aOikPqD2NDQPV0WM//CXGcS6xiD0rNkqHmw6FEg4tabt4nxPLwgCWT+Vb2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "4.0.5"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.5.tgz",
+      "integrity": "sha512-7xrBTqIts3o+PMUZX97wSc+7TUbW+/rULzGNCTP6yooNVDXbzw4Wutg/H/xOutTB/c/k0YqOAavgPh4/Zk9PFA==",
+      "license": "MIT"
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -24001,6 +24017,19 @@
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
       "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
       "requires": {}
+    },
+    "@dagrejs/dagre": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.1.1.tgz",
+      "integrity": "sha512-zroZB1dFOFiGgv4Xcrn1DckB1o4aOikPqD2NDQPV0WM//CXGcS6xiD0rNkqHmw6FEg4tabt4nxPLwgCWT+Vb2A==",
+      "requires": {
+        "@dagrejs/graphlib": "4.0.5"
+      }
+    },
+    "@dagrejs/graphlib": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.5.tgz",
+      "integrity": "sha512-7xrBTqIts3o+PMUZX97wSc+7TUbW+/rULzGNCTP6yooNVDXbzw4Wutg/H/xOutTB/c/k0YqOAavgPh4/Zk9PFA=="
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@dagrejs/dagre": "^3.1.1",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.14.6",

--- a/src/components/CanvasEditor/Header/Menu/Menu.jsx
+++ b/src/components/CanvasEditor/Header/Menu/Menu.jsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from "react";
 import { Tooltip } from "@mui/material";
 import Divider from "@mui/material/Divider";
-import { Lock, Unlock, Trash2 } from "lucide-react";
+import { Lock, Unlock, Trash2, Network } from "lucide-react";
 import removeCursor from "../../../../assets/icons/circle.svg";
+import { arrangeDiagram } from "../../../../utils/autoLayout";
 import GenericDialog from "../../../Dialog/ConsentDialog";
 import BackgroundColor from "../../BackgroundColor";
 import IconLibrary from "../../IconLibrary/IconLibrary";
@@ -58,6 +59,11 @@ const Menu = () => {
     setIsDeleteDialogOpen(false);
   };
 
+  // Tidy the bound diagram into a clean layered flow (auto-layout).
+  const handleArrange = () => {
+    if (canvas) arrangeDiagram(canvas);
+  };
+
   const handleBackgroundClose = () => {
     setIsOpenBackground(false);
     setActiveTool(TOOL_CONSTANTS.CURSOR);
@@ -99,6 +105,13 @@ const Menu = () => {
             );
           })}
           <Divider orientation="vertical" flexItem />
+          <Tooltip title={"Arrange (auto-layout)"}>
+            <Network
+              className="menu-container__button"
+              size={ICON_SIZE}
+              onClick={handleArrange}
+            />
+          </Tooltip>
           <Tooltip title={"Delete entire canvas"}>
             <Trash2
               className="menu-container__button"

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -37,6 +37,12 @@ if (typeof HTMLCanvasElement !== "undefined") {
   };
 }
 
+// @dagrejs/dagre uses structuredClone (a modern-browser/Node-17+ global) which
+// jsdom lacks; a JSON deep-clone is enough for its plain-data graph.
+if (typeof globalThis.structuredClone === "undefined") {
+  globalThis.structuredClone = (v) => JSON.parse(JSON.stringify(v));
+}
+
 if (typeof window !== "undefined" && !window.matchMedia) {
   window.matchMedia = (query) => ({
     matches: false,

--- a/src/utils/autoLayout.js
+++ b/src/utils/autoLayout.js
@@ -1,0 +1,123 @@
+import { fabric } from "fabric";
+import * as dagre from "@dagrejs/dagre";
+import { isArrow } from "./shapeLabel";
+import { isBindable, boundArrows, rerouteArrow } from "./binding";
+
+// Auto-layout ("Arrange"): tidy a bound diagram into a clean layered flow. The
+// graph is read from the canvas — bindable shapes are nodes, arrows bound at
+// BOTH ends are edges — laid out with dagre (the Sugiyama layout mermaid uses),
+// then shapes are moved to their new spots and their arrows re-routed. This is
+// also the layout the future IR->canvas render will reuse.
+
+export const DEFAULT_LAYOUT = {
+  rankdir: "TB", // top-to-bottom flow
+  nodesep: 60, // gap between siblings in a rank
+  ranksep: 90, // gap between ranks
+};
+
+// Read the diagram as a graph. Nodes = shapes that are an endpoint of at least
+// one fully-bound arrow (so unconnected shapes are left untouched). Returns
+// { nodes: [{id,w,h,cx,cy}], edges: [{from,to}] }.
+export const extractGraph = (canvas) => {
+  const byId = new Map();
+  canvas.getObjects().forEach((o) => {
+    if (o && o.id && isBindable(o)) byId.set(o.id, o);
+  });
+  const edges = [];
+  const nodeIds = new Set();
+  canvas.getObjects().forEach((o) => {
+    if (!isArrow(o)) return;
+    const from = o.startBinding;
+    const to = o.endBinding;
+    if (from && to && byId.has(from) && byId.has(to) && from !== to) {
+      edges.push({ from, to });
+      nodeIds.add(from);
+      nodeIds.add(to);
+    }
+  });
+  const nodes = [...nodeIds].map((id) => {
+    const b = byId.get(id).getBoundingRect(true, true);
+    return {
+      id,
+      w: b.width,
+      h: b.height,
+      cx: b.left + b.width / 2,
+      cy: b.top + b.height / 2,
+    };
+  });
+  return { nodes, edges };
+};
+
+// Pure layout: run dagre over the node/edge lists and return a Map of
+// id -> { cx, cy } (new centres), translated so the result stays centred where
+// the diagram already is (no jarring jump). Null when there's nothing to lay out.
+export const layoutGraph = (nodes, edges, opts = {}) => {
+  if (!nodes || nodes.length < 2 || !edges || !edges.length) return null;
+  const cfg = { ...DEFAULT_LAYOUT, ...opts };
+  const g = new dagre.graphlib.Graph();
+  g.setGraph({
+    rankdir: cfg.rankdir,
+    nodesep: cfg.nodesep,
+    ranksep: cfg.ranksep,
+  });
+  g.setDefaultEdgeLabel(() => ({}));
+  nodes.forEach((n) => g.setNode(n.id, { width: n.w, height: n.h }));
+  edges.forEach((e) => {
+    if (g.hasNode(e.from) && g.hasNode(e.to)) g.setEdge(e.from, e.to);
+  });
+  dagre.layout(g);
+
+  // Translate the laid-out graph so its centroid matches the diagram's current
+  // centroid — keeps the arranged diagram roughly where the user had it.
+  const laid = nodes
+    .map((n) => ({ id: n.id, p: g.node(n.id) }))
+    .filter((x) => x.p);
+  if (!laid.length) return null;
+  const avg = (arr, f) => arr.reduce((s, x) => s + f(x), 0) / arr.length;
+  const oldCx = avg(nodes, (n) => n.cx);
+  const oldCy = avg(nodes, (n) => n.cy);
+  const newCx = avg(laid, (x) => x.p.x);
+  const newCy = avg(laid, (x) => x.p.y);
+  const dx = oldCx - newCx;
+  const dy = oldCy - newCy;
+  const out = new Map();
+  laid.forEach((x) => out.set(x.id, { cx: x.p.x + dx, cy: x.p.y + dy }));
+  return out;
+};
+
+// Apply an auto-layout to the canvas: move each connected shape to its new
+// centre, re-route its bound arrows, and record a single undo step. Returns true
+// if anything was arranged.
+export const arrangeDiagram = (canvas, opts = {}) => {
+  const { nodes, edges } = extractGraph(canvas);
+  const positions = layoutGraph(nodes, edges, opts);
+  if (!positions) return false;
+
+  const canBatch = typeof canvas._historySaveAction === "function";
+  if (canBatch) canvas.historyProcessing = true;
+  try {
+    positions.forEach((pos, id) => {
+      const shape = canvas.getObjects().find((o) => o.id === id);
+      if (!shape) return;
+      shape.setPositionByOrigin(
+        new fabric.Point(pos.cx, pos.cy),
+        "center",
+        "center",
+      );
+      shape.setCoords();
+    });
+    // Re-route every arrow touching a moved shape so connectors follow.
+    const arrows = new Set();
+    positions.forEach((_pos, id) =>
+      boundArrows(canvas, id).forEach((a) => arrows.add(a)),
+    );
+    arrows.forEach((a) => rerouteArrow(canvas, a));
+  } finally {
+    if (canBatch) {
+      canvas.historyProcessing = false;
+      canvas._historySaveAction();
+    }
+  }
+  canvas.requestRenderAll();
+  return true;
+};

--- a/src/utils/autoLayout.test.js
+++ b/src/utils/autoLayout.test.js
@@ -1,0 +1,45 @@
+import { layoutGraph } from "./autoLayout";
+
+const node = (id, cx, cy) => ({ id, w: 100, h: 60, cx, cy });
+
+describe("layoutGraph", () => {
+  test("returns null when there's nothing to lay out", () => {
+    expect(layoutGraph([], [])).toBeNull();
+    expect(layoutGraph([node("a", 0, 0)], [])).toBeNull(); // single node
+    expect(layoutGraph([node("a", 0, 0), node("b", 0, 0)], [])).toBeNull(); // no edges
+  });
+
+  test("lays a chain A->B->C into descending ranks (top-to-bottom)", () => {
+    const nodes = [node("a", 0, 0), node("b", 0, 0), node("c", 0, 0)];
+    const edges = [
+      { from: "a", to: "b" },
+      { from: "b", to: "c" },
+    ];
+    const pos = layoutGraph(nodes, edges);
+    expect(pos).not.toBeNull();
+    const a = pos.get("a");
+    const b = pos.get("b");
+    const c = pos.get("c");
+    // each rank is strictly below the previous
+    expect(b.cy).toBeGreaterThan(a.cy);
+    expect(c.cy).toBeGreaterThan(b.cy);
+  });
+
+  test("keeps the layout centred on the diagram's current centroid", () => {
+    const nodes = [node("a", 500, 300), node("b", 520, 320)];
+    const edges = [{ from: "a", to: "b" }];
+    const pos = layoutGraph(nodes, edges);
+    const cx = (pos.get("a").cx + pos.get("b").cx) / 2;
+    const cy = (pos.get("a").cy + pos.get("b").cy) / 2;
+    // new centroid ≈ old centroid (510, 310), within rounding
+    expect(Math.round(cx)).toBe(510);
+    expect(Math.round(cy)).toBe(310);
+  });
+
+  test("respects rankdir LR (siblings flow left-to-right)", () => {
+    const nodes = [node("a", 0, 0), node("b", 0, 0)];
+    const edges = [{ from: "a", to: "b" }];
+    const pos = layoutGraph(nodes, edges, { rankdir: "LR" });
+    expect(pos.get("b").cx).toBeGreaterThan(pos.get("a").cx);
+  });
+});


### PR DESCRIPTION
## What changed
Adds **auto-layout** — the foundation for the AI-diagram track, and useful on its own.

- `utils/autoLayout.js`: reads the canvas as a graph (bindable shapes = nodes, arrows bound at **both** ends = edges), lays it out with **dagre** (the Sugiyama layout mermaid uses), then moves shapes to their computed spots and re-routes their arrows — all in **one undo step**. Unconnected shapes are left alone; the result is re-centred where the diagram already was.
- Toolbar **"Arrange"** action (lucide `Network` icon, next to Delete-canvas) runs it.

## Why
Manual box-placement is the biggest tax in drawing diagrams, and auto-layout is the prerequisite for everything downstream (mermaid import, prompt→diagram). `layoutGraph` is a pure function, so the coming **IR→canvas render** reuses it directly.

## Notes
- dep: `@dagrejs/dagre@3.1.1` — no `engines` floor, so the Cloudflare Pages build is safe.
- `setupTests.js` polyfills `structuredClone` (dagre uses it; jsdom lacks it — it exists at runtime in modern browsers).

## Test plan
- New `autoLayout.test.js`: null on empty/edgeless graphs, A→B→C descends into ranks, centroid preserved, `rankdir: LR` flows left-to-right. 93 tests pass; lint + prettier clean.
- Verified in-browser: a crisscrossed 4-node bound diagram tidies into a clean top-to-bottom flow (A → B/C → D) with arrows re-routed and glued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)