### PR TITLE
fix: restore arrow endpoint handles after reload/undo

### DIFF
--- a/src/Handlers/EventHandlers/arrowEndpointHandler.js
+++ b/src/Handlers/EventHandlers/arrowEndpointHandler.js
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+import { useCanvasContext } from "../../hooks";
+import { isArrow } from "../../utils/shapeLabel";
+import { attachEndpointControls } from "../../utils/arrowEndpoints";
+
+// Give a selected arrow its endpoint drag-handles back. buildArrowGroup installs
+// them (plus hasBorders:false / perPixelTargetFind), but controls aren't
+// serialized — so an arrow restored from a saved scene, or rebuilt by an
+// undo/redo loadFromJSON, would otherwise show default bbox handles in the wrong
+// spots. Re-attaching on selection covers every load path (mirrors
+// LineEndpointHandler).
+function ArrowEndpointHandler() {
+  const { canvas } = useCanvasContext();
+
+  useEffect(() => {
+    if (!canvas) return undefined;
+    const onSelect = () => {
+      const t = canvas.getActiveObject();
+      if (t && isArrow(t) && !t.group) {
+        attachEndpointControls(t);
+        t.set({ perPixelTargetFind: true, objectCaching: false });
+      }
+    };
+    canvas.on("selection:created", onSelect);
+    canvas.on("selection:updated", onSelect);
+    return () => {
+      canvas.off("selection:created", onSelect);
+      canvas.off("selection:updated", onSelect);
+    };
+  }, [canvas]);
+}
+
+export default ArrowEndpointHandler;

--- a/src/Handlers/EventHandlers/index.js
+++ b/src/Handlers/EventHandlers/index.js
@@ -4,6 +4,7 @@ export { default as SelectionHandler } from "./selectionHandler";
 export { default as TextEventHandler } from "./textEventHandler";
 export { default as LabelHandler } from "./labelHandler";
 export { default as LineEndpointHandler } from "./lineEndpointHandler";
+export { default as ArrowEndpointHandler } from "./arrowEndpointHandler";
 export { default as DarkColorHandler } from "./darkColorHandler";
 export { default as ZoomHandler } from "./zoomHandler";
 export { default as PersistenceHandler } from "./persistenceHandler";

--- a/src/components/Canvas/Canvas.jsx
+++ b/src/components/Canvas/Canvas.jsx
@@ -9,6 +9,7 @@ import {
   SelectionHandler,
   LabelHandler,
   LineEndpointHandler,
+  ArrowEndpointHandler,
   TextEventHandler,
   ZoomHandler,
   PersistenceHandler,
@@ -29,6 +30,7 @@ function Canvas() {
   // shape+text regroup happens before the generic empty-text cleanup.
   LabelHandler();
   LineEndpointHandler();
+  ArrowEndpointHandler();
   TextEventHandler();
   ZoomHandler();
   PersistenceHandler();


### PR DESCRIPTION
## The bug
After an arrow is drawn, reopening the tab (restore from IndexedDB) — or an undo/redo — showed the arrow with **default bbox handles in the wrong positions** instead of its two endpoint dots.

## Root cause
`buildArrowGroup` installs custom endpoint controls (plus `hasBorders:false` and `perPixelTargetFind`) on the group instance. Those aren't serialized, so any `loadFromJSON` (IndexedDB restore **and** undo/redo) produces an arrow with fabric's default controls.

## Fix
`ArrowEndpointHandler` — on `selection:created/updated`, re-attach the endpoint controls (and `perPixelTargetFind`) to a selected top-level arrow. Mirrors the existing `LineEndpointHandler`, so it covers every load path, not just initial reload.

## Test plan
- 89 tests pass; lint + prettier clean.
- Verified in-browser: drew a bound arrow → waited for the debounced save → reloaded. Right after restore the arrow carried default handles (`ml,mr,mt,mb,tl,tr,bl,br,mtr`); after selecting it the controls were back to `e1,e2` with `hasBorders:false` and `perPixelTargetFind:true` — the correct endpoint dots (screenshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)